### PR TITLE
feat(remix): give the two effect Mixes their dot-shorthand pair

### DIFF
--- a/packages/remix/lib/src/rendering/remix_box_effects_model.dart
+++ b/packages/remix/lib/src/rendering/remix_box_effects_model.dart
@@ -127,12 +127,68 @@ class RemixBoxShadowMix extends Mix<RemixBoxShadow> {
         shapeInset: value.shapeInset,
       );
 
+  /// Which of the shadow shapes this is: a drop shadow or an inner shadow.
+  ///
+  /// Named so a shadow can be written as a dot shorthand wherever one is
+  /// expected, matching [RemixBoxEffectsMix]. See [kind] for the chainable
+  /// counterpart that continues the same expression.
+  factory RemixBoxShadowMix.kind(RemixBoxShadowKind value) =>
+      RemixBoxShadowMix(kind: value);
+
+  /// The shadow's color.
+  factory RemixBoxShadowMix.color(Color value) =>
+      RemixBoxShadowMix(color: value);
+
+  /// How far the shadow is displaced from the box.
+  factory RemixBoxShadowMix.offset(Offset value) =>
+      RemixBoxShadowMix(offset: value);
+
+  /// How far the shadow's edge is blurred.
+  factory RemixBoxShadowMix.blurRadius(double value) =>
+      RemixBoxShadowMix(blurRadius: value);
+
+  /// How far the shadow grows beyond the box before blurring.
+  factory RemixBoxShadowMix.spreadRadius(double value) =>
+      RemixBoxShadowMix(spreadRadius: value);
+
+  /// Inset applied to the shape an inner shadow is cut from.
+  factory RemixBoxShadowMix.shapeInset(double value) =>
+      RemixBoxShadowMix(shapeInset: value);
+
   final Prop<RemixBoxShadowKind>? $kind;
   final Prop<Color>? $color;
   final Prop<Offset>? $offset;
   final Prop<double>? $blurRadius;
   final Prop<double>? $spreadRadius;
   final Prop<double>? $shapeInset;
+
+  /// Chainable counterpart of [RemixBoxShadowMix.kind].
+  ///
+  /// A named constructor and an instance method may share a name in Dart, so
+  /// the same word works as the entry point and as a link in a chain:
+  /// `.shadows([.color(black).blurRadius(12)])`.
+  RemixBoxShadowMix kind(RemixBoxShadowKind value) =>
+      merge(RemixBoxShadowMix(kind: value));
+
+  /// Chainable counterpart of [RemixBoxShadowMix.color].
+  RemixBoxShadowMix color(Color value) =>
+      merge(RemixBoxShadowMix(color: value));
+
+  /// Chainable counterpart of [RemixBoxShadowMix.offset].
+  RemixBoxShadowMix offset(Offset value) =>
+      merge(RemixBoxShadowMix(offset: value));
+
+  /// Chainable counterpart of [RemixBoxShadowMix.blurRadius].
+  RemixBoxShadowMix blurRadius(double value) =>
+      merge(RemixBoxShadowMix(blurRadius: value));
+
+  /// Chainable counterpart of [RemixBoxShadowMix.spreadRadius].
+  RemixBoxShadowMix spreadRadius(double value) =>
+      merge(RemixBoxShadowMix(spreadRadius: value));
+
+  /// Chainable counterpart of [RemixBoxShadowMix.shapeInset].
+  RemixBoxShadowMix shapeInset(double value) =>
+      merge(RemixBoxShadowMix(shapeInset: value));
 
   @override
   RemixBoxShadowMix merge(RemixBoxShadowMix? other) {
@@ -558,9 +614,50 @@ class RemixBoxEffectLayerMix extends Mix<RemixBoxEffectLayerSpec> {
        $gradientInsets = gradientInsets,
        $shadows = shadows;
 
+  /// The shadows this layer paints.
+  ///
+  /// Named so a layer can be written as a dot shorthand wherever one is
+  /// expected, matching [RemixBoxEffectsMix]:
+  /// `.containerEffects(.behindContent(.shadows([shadow])))`.
+  factory RemixBoxEffectLayerMix.shadows(List<RemixBoxShadowMix> value) =>
+      RemixBoxEffectLayerMix(shadows: value);
+
+  /// Resolves the layer's shadows from a token rather than a literal list.
+  factory RemixBoxEffectLayerMix.shadowToken(RemixBoxShadowListToken value) =>
+      RemixBoxEffectLayerMix(shadowToken: value);
+
+  /// The gradients this layer paints.
+  factory RemixBoxEffectLayerMix.gradients(
+    List<RemixLinearGradientMix> value,
+  ) => RemixBoxEffectLayerMix(gradients: value);
+
+  /// Per-gradient insets, applied in the same order as [gradients].
+  factory RemixBoxEffectLayerMix.gradientInsets(List<double> value) =>
+      RemixBoxEffectLayerMix(gradientInsets: value);
+
   final Prop<List<Gradient>>? $gradients;
   final Prop<List<double>>? $gradientInsets;
   final Prop<List<RemixBoxShadow>>? $shadows;
+
+  /// Chainable counterpart of [RemixBoxEffectLayerMix.shadows].
+  ///
+  /// A named constructor and an instance method may share a name in Dart, so
+  /// the same word works as the entry point and as a link in a chain:
+  /// `.behindContent(.gradients([gradient]).shadows([shadow]))`.
+  RemixBoxEffectLayerMix shadows(List<RemixBoxShadowMix> value) =>
+      merge(RemixBoxEffectLayerMix(shadows: value));
+
+  /// Chainable counterpart of [RemixBoxEffectLayerMix.shadowToken].
+  RemixBoxEffectLayerMix shadowToken(RemixBoxShadowListToken value) =>
+      merge(RemixBoxEffectLayerMix(shadowToken: value));
+
+  /// Chainable counterpart of [RemixBoxEffectLayerMix.gradients].
+  RemixBoxEffectLayerMix gradients(List<RemixLinearGradientMix> value) =>
+      merge(RemixBoxEffectLayerMix(gradients: value));
+
+  /// Chainable counterpart of [RemixBoxEffectLayerMix.gradientInsets].
+  RemixBoxEffectLayerMix gradientInsets(List<double> value) =>
+      merge(RemixBoxEffectLayerMix(gradientInsets: value));
 
   @override
   RemixBoxEffectLayerMix merge(RemixBoxEffectLayerMix? other) {

--- a/packages/remix/test/rendering/remix_box_effects_test.dart
+++ b/packages/remix/test/rendering/remix_box_effects_test.dart
@@ -204,6 +204,73 @@ void main() {
     });
   });
 
+  group('effect Mixes carry the dot-shorthand pair', () {
+    // Every field gets a named constructor and an instance method under the
+    // same word, so the same name works as the entry point of an expression
+    // and as a link in its chain. These tests are written in the shorthand
+    // form on purpose: if a static counterpart went missing the file would
+    // stop compiling, which is the assertion.
+
+    test('a layer constructor sets its own field and nothing else', () {
+      final shadow = RemixBoxShadowMix(blurRadius: 12);
+      expect(
+        RemixBoxEffectLayerMix.shadows([shadow]),
+        RemixBoxEffectLayerMix(shadows: [shadow]),
+      );
+      expect(
+        RemixBoxEffectLayerMix.gradientInsets(const [1, 2]),
+        RemixBoxEffectLayerMix(gradientInsets: const [1, 2]),
+      );
+    });
+
+    test('a shadow constructor sets its own field and nothing else', () {
+      expect(
+        RemixBoxShadowMix.blurRadius(12),
+        RemixBoxShadowMix(blurRadius: 12),
+      );
+      expect(
+        RemixBoxShadowMix.color(const Color(0xFF00FF00)),
+        RemixBoxShadowMix(color: const Color(0xFF00FF00)),
+      );
+      expect(
+        RemixBoxShadowMix.offset(const Offset(0, 4)),
+        RemixBoxShadowMix(offset: const Offset(0, 4)),
+      );
+    });
+
+    test('the chainable counterpart merges rather than replaces', () {
+      final chained = RemixBoxShadowMix.color(
+        const Color(0xFF00FF00),
+      ).blurRadius(12).offset(const Offset(0, 4));
+
+      expect(
+        chained,
+        RemixBoxShadowMix(
+          color: const Color(0xFF00FF00),
+          blurRadius: 12,
+          offset: const Offset(0, 4),
+        ),
+      );
+    });
+
+    test('a whole layer reads as one shorthand expression', () {
+      final RemixBoxEffectsMix shorthand = .behindContent(
+        .shadows([.color(const Color(0x1A000000)).blurRadius(12)]),
+      );
+
+      expect(
+        shorthand,
+        RemixBoxEffectsMix(
+          behindContent: RemixBoxEffectLayerMix(
+            shadows: [
+              RemixBoxShadowMix(color: const Color(0x1A000000), blurRadius: 12),
+            ],
+          ),
+        ),
+      );
+    });
+  });
+
   group('Box effects geometry', () {
     testWidgets('preserves mutable child state across Box renderer routes', (
       tester,


### PR DESCRIPTION
`RemixBoxEffectsMix` already carried the pattern: one named constructor and one
chainable instance method per field, sharing a word, so the same name works as
the entry point of an expression and as a link in its chain. Its two siblings
did not, which meant a shorthand expression ran out of road one level down —
`.containerEffects(.behindContent(...))` was fine, but the layer inside it had
to be spelled out in full.

`RemixBoxShadowMix` now has the pair for `kind`, `color`, `offset`,
`blurRadius`, `spreadRadius`, and `shapeInset`; `RemixBoxEffectLayerMix` for
`shadows`, `shadowToken`, `gradients`, and `gradientInsets`. A whole effect now
reads as one expression:

```dart
.containerEffects(
  .behindContent(.shadows([.color(shadowColor).blurRadius(12)])),
)
```

The instance methods merge rather than replace, matching the existing ones, so
a chain accumulates and a field a later link does not name is left alone.

## Why this is on its own branch

This is the change that blocks the open-code registry. Templates ship to
consumers who resolve `remix` from pub.dev, and `tool/check_open_code.dart`
enforces that by building a throwaway app that resolves hosted **before**
retesting against the checkout. So a template cannot use this API until it is
published. Splitting it out lets it merge and release on its own, without
waiting on anything downstream.

Nothing depends on it yet — `feat/open-code` still spells these out in full and
passes its full check against hosted `1.0.0-beta.6`. Merging this is purely
additive.

## Verification

- Purely additive: 164 insertions, 0 deletions, 2 files.
- `dart analyze packages/remix` clean, formatter clean.
- 2,727 `remix` tests pass, including four new ones.

The new tests are written in the shorthand form deliberately. A dot shorthand
resolves only against static members and constructors of the declared context
type, so if a static counterpart went missing the test file would stop
compiling — that is the assertion, and it is stronger than comparing values.