### PR TITLE
fix(ci): let the version workflow reach a remote for its tags

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -68,7 +68,14 @@ jobs:
           dart pub global activate melos
           melos bootstrap
 
-          git checkout -b release/version-packages
+          # Versioning happens on the checked-out branch, and the release
+          # branch is cut afterwards from the modified tree. `melos version`
+          # opens with `git pull --tags -f` to refresh the `<package>-v*` tags
+          # it derives each last release from, and a branch made here with
+          # `git checkout -b` has no upstream, so that pull aborts with "there
+          # is no tracking information for the current branch" before melos
+          # writes anything. Running while the tracking branch actions/checkout
+          # set up is still current is what gives that pull a remote to read.
 
           # `--no-git-commit-version` is what makes the diff check below
           # meaningful. melos commits by default, which would leave a clean tree
@@ -79,7 +86,15 @@ jobs:
           # `stdin.hasTerminal` is false, and `--yes` does not cover it, so the
           # redirect is what guarantees the default instead of a runner that
           # happens to have no tty.
-          melos version --no-git-commit-version --yes $overrides < /dev/null
+          # Scope is explicit so a conventional commit touching remix_cli
+          # cannot pull that independently versioned package into the lockstep
+          # Remix/Fortal release branch.
+          melos version \
+            --scope=remix \
+            --scope=remix_fortal \
+            --no-git-commit-version \
+            --yes \
+            $overrides < /dev/null
 
           # The pair must land aligned; verify rather than trust the inputs.
           dart run tool/check_version_alignment.dart
@@ -90,6 +105,9 @@ jobs:
             exit 0
           fi
           echo "versioned=true" >> "$GITHUB_OUTPUT"
+
+          # Cut the branch now, carrying the working tree melos just wrote.
+          git checkout -b release/version-packages
 
           git add -A
           git commit -m "chore(release): version packages"


### PR DESCRIPTION
The first dispatch of **Prepare Version Bump** ([run](https://github.com/conceptadev/remix/actions/runs/33198099690)) failed before melos wrote anything:

```
ProcessException: Melos: Failed executing a git command:
There is no tracking information for the current branch.
  Command: git pull --tags -f
```

## What broke

`melos version` opens by refreshing the `<package>-v*` tags it derives each package's last release from, using `git pull --tags -f`. The workflow cut `release/version-packages` with `git checkout -b` *before* that. A branch made that way from a local branch inherits no upstream — unlike one made from a remote-tracking ref, where `branch.autoSetupMerge` supplies it — so the pull had no remote to read.

Reproduced in a throwaway worktree rather than inferred:

```
$ git worktree add /tmp/probe -b base origin/main
$ git rev-parse --abbrev-ref @{u}        # origin/main   <- auto-set
$ git checkout -b release/version-packages-probe
$ git rev-parse --abbrev-ref @{u}        # fatal: no upstream configured
$ git pull --tags -f                     # same error CI produced
```

## Fixes

1. **Version on the tracking branch, cut the release branch after.** Versioning runs while the branch `actions/checkout` set up is still current, then the release branch is cut from the tree melos wrote. The "no packages required versioning" early exit now also returns before creating a branch it would never push.

2. **Restore the `--scope` flags.** These existed only on the open-code branch. Without them `melos version` versions every package with a conventional commit since its last tag, so the dispatched run would have pulled independently versioned `remix_cli` into a lockstep Remix/Fortal release — the second failure the run would have hit had it got past the first.

This workflow had never been run before, so neither bug had a chance to surface.

## Verification

YAML parses; the release branch is cut after `melos version`; both scope flags present; exactly one real `git checkout -b`. The workflow itself is only exercised by dispatching it, which is the next step after this merges.