### PR TITLE
fix(ci): move the workspace to melos 8 so `--yes` reaches the release prompt

### DIFF
--- a/.github/workflows/deploy_web.yml
+++ b/.github/workflows/deploy_web.yml
@@ -35,11 +35,13 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
-      - name: Install Melos
-        run: dart pub global activate melos
-
+      # Resolve the workspace and run its own melos rather than installing one
+      # globally: melos delegates to the version pinned in the root pubspec, so
+      # a global install cannot decide the version.
       - name: Bootstrap workspace
-        run: melos bootstrap
+        run: |
+          dart pub get
+          dart run melos bootstrap
 
       - name: Build component catalog
         working-directory: apps/demo

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -65,8 +65,14 @@ jobs:
           # keeps them identical.
           overrides="-V remix:$version -V remix_fortal:$version"
 
-          dart pub global activate melos
-          melos bootstrap
+          # No `dart pub global activate melos`. melos runs whichever version
+          # the workspace pins as a dev dependency, so a global install cannot
+          # decide the version and only prints a reassuring, wrong one into the
+          # log — which is how a 7.8.2 crash came to be reported under an
+          # "Activated melos 8.5.0" line. Resolving the workspace and running
+          # its own melos makes the pin the single source of truth.
+          dart pub get
+          dart run melos bootstrap
 
           # Versioning happens on the checked-out branch, and the release
           # branch is cut afterwards from the modified tree. `melos version`
@@ -81,15 +87,18 @@ jobs:
           # meaningful. melos commits by default, which would leave a clean tree
           # and make a successful run look like "nothing to version". It also
           # implies --no-git-tag-version.
-          # `< /dev/null` because manual `-V` versioning asks whether you want
-          # an extra changelog entry. melos only skips that prompt when
-          # `stdin.hasTerminal` is false, and `--yes` does not cover it, so the
-          # redirect is what guarantees the default instead of a runner that
-          # happens to have no tty.
+          # `--yes` is what skips the changelog-entry prompt manual `-V`
+          # versioning would otherwise raise. That is true from melos 8.0.0,
+          # which put the flag in front of it; on 7.x the prompt was
+          # unconditional and this workflow crashed on it. `< /dev/null` is
+          # kept as a second line of defence for any prompt added later, but it
+          # is not what makes this work: melos re-executes itself and the
+          # child does not inherit the redirect, so a redirected stdin alone
+          # still reached the prompt and threw StdinException.
           # Scope is explicit so a conventional commit touching remix_cli
           # cannot pull that independently versioned package into the lockstep
           # Remix/Fortal release branch.
-          melos version \
+          dart run melos version \
             --scope=remix \
             --scope=remix_fortal \
             --no-git-commit-version \
@@ -124,8 +133,16 @@ jobs:
             echo
             echo "Both packages are on \`${{ inputs.version }}\`."
             echo
-            echo "After merging, push the release tags in order:"
-            echo '1. `remix-v${{ inputs.version }}` — wait until pub.dev serves it'
-            echo '2. `remix_fortal-v${{ inputs.version }}`'
+            echo "After merging, push these tags ONE AT A TIME, in this order."
+            echo "Do not \`git push --tags\`: stale \`v*\` tags in this repo"
+            echo "would start publish runs from the wrong commits."
+            echo
+            echo '1. `v${{ inputs.version }}` — publishes **remix**. Wait until'
+            echo '   pub.dev actually serves it before step 2; pub.dev does not'
+            echo '   verify a dependency exists, so publishing remix_fortal'
+            echo '   early ships an uninstallable package rather than failing.'
+            echo '2. `remix_fortal-v${{ inputs.version }}` — publishes **remix_fortal**.'
+            echo '3. `remix-v${{ inputs.version }}` — publishes nothing. melos'
+            echo '   reads it to derive the next release changelog.'
           } >> "$GITHUB_STEP_SUMMARY"
           echo "Open the pull request: $url"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -412,10 +412,10 @@ packages:
     dependency: "direct dev"
     description:
       name: melos
-      sha256: "5fc1a858e3d90fdc42f2f423b95f901214bbc3d9e80c99125d9352f12453721d"
+      sha256: f910f0f48f02aeb3fa1b63d72ffb014f7db9a8995b42969b2bc756ea36463d1b
       url: "https://pub.dev"
     source: hosted
-    version: "7.8.2"
+    version: "8.5.0"
   meta:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ environment:
   flutter: ">=3.44.0"
 
 dev_dependencies:
-  melos: ^7.1.1
+  melos: ^8.5.0
   flutter_lints: ^6.0.0
   build_runner: ^2.10.1
   pub_semver: ^2.2.0
@@ -67,20 +67,20 @@ melos:
     # `.github/workflows/version.yml` is the only supported path: it takes one
     # version and applies it to both packages with `-V`.
     generate:
-      run: dart run build_runner build
       description: Regenerate Remix sources
       # remix_fortal's generator resolves package:remix, so it must not build
       # while remix is rewriting its own lib/.
       exec:
+        command: dart run build_runner build
         concurrency: 1
         orderDependents: true
       packageFilters:
         scope: [remix, remix_fortal]
 
     generate:check:
-      run: dart run ../../tool/check_generated.dart
       description: Regenerate Remix sources and fail only on generated drift
       exec:
+        command: dart run ../../tool/check_generated.dart
         concurrency: 1
         orderDependents: true
       packageFilters:


### PR DESCRIPTION
The second dispatch of **Prepare Version Bump** ([run](https://github.com/conceptadev/remix/actions/runs/33199424057)) cleared the tracking bug from #170 and died on a different one:

```
StdinException: Error getting terminal echo mode, OS Error: Inappropriate ioctl for device, errno = 25
  prompts.getBool -> promptBool -> _promptWithTerminal -> _VersionMixin._version (version.dart:300)
```

## The melos that ran is not the one the log names

The workflow runs `dart pub global activate melos` and the log says `Activated melos 8.5.0`. That is not the melos that executed. **melos delegates to the version the workspace pins**, and this pubspec pinned `^7.1.1` → 7.8.2.

Demonstrated directly — one binary on `PATH`, version chosen by the workspace:

```
$ cd /tmp && melos --version                    # 8.5.0   (global)
$ cd <workspace pinned ^7.1.1> && melos --version   # 7.8.2
$ cd <workspace pinned ^8.5.0> && melos --version   # 8.5.0
```

Every line number in the crash matches 7.8.2, not 8.5.0:

| CI stack | melos 7.8.2 | melos 8.5.0 |
|---|---|---|
| `utils.dart:193` | `return runPrompt();` | line 207, wrapped in `try/catch` |
| `utils.dart:240` | `prompts.getBool` closure | line 260 |
| `version.dart:300` | `promptForMessage = promptBool(...)` | line 272, behind `!force &&` |

In 7.8.2 that prompt is unconditional. 8.0.0 put `--yes` in front of it, with a comment stating exactly what the workflow already assumed was true:

```dart
// `--yes`/`force` skips all confirmation prompts, so never prompt here
promptForMessage = !force && promptBool(...);
```

8.x also wraps the prompt in `try/catch on StdinException` and degrades to the non-interactive default instead of crashing. 7.8.2 has neither guard.

## Why `< /dev/null` never helped

The workflow already redirects stdin, and its comment explains that this is what makes melos skip the prompt. That reasoning does not hold. Reproduced locally on the current pin, with the redirect in place, on a tracking branch so it gets past #170:

```
$ melos version --scope=remix --scope=remix_fortal --no-git-commit-version --yes \
    -V remix:1.0.0-beta.7 -V remix_fortal:1.0.0-beta.7 < /dev/null

Found commits for manually versioned package "remix".
StdinException: Error getting terminal echo mode, errno = 19
  #3 promptBool.<anonymous closure> (utils.dart:240:19)
  #4 _promptWithTerminal (utils.dart:193:21)
```

Same failure as CI, same lines; errno differs only because this is macOS rather than Linux. So `stdin.hasTerminal` is still true inside melos despite the redirect. The likely reason is that melos re-executes itself through its launcher and the child does not inherit the redirected stdin, but that mechanism is an inference — the fix does not depend on it. What is established is that the redirect does not prevent the prompt, and `--yes` on 7.8.2 does not either.

Bumping the pin is what actually changes behaviour, and it makes the workflow's `activate` honest: global and workspace melos become the same version.

## Script migration

melos 8 made `run` and `exec` mutually exclusive. The two scripts that used `run` for the command and `exec` for its options move the command under `exec.command`. `test:flutter` and `fortal:parity:check` use the `exec: <string>` shorthand, which is unchanged.

## Verification

Run end to end locally against this pubspec before opening:

- `melos bootstrap` → `5 packages bootstrapped`
- the exact failing command now completes:

```
remix          1.0.0-beta.6 -> 1.0.0-beta.7   manual versioning
remix_fortal   1.0.0-beta.6 -> 1.0.0-beta.7   manual versioning
Versioning successful.
```

- changelogs correct, `check_version_alignment` passes on 1.0.0-beta.7