### PR TITLE
fix(remix): let naked_ui resolve as a range so the packages can publish

### DIFF
--- a/packages/remix/pubspec.yaml
+++ b/packages/remix/pubspec.yaml
@@ -29,9 +29,10 @@ dependencies:
   mix_annotations: ^2.2.0-beta.1
   # Ranged, not pinned: pub.dev rejects an exact hosted constraint with
   # "your dependency should allow more than one version" and the publish
-  # exits 65. beta.14 is the current latest, so this resolves identically
-  # today; it only stops the constraint fighting other packages that also
-  # depend on naked_ui.
+  # exits 65. The floor is the release the Fortal parity contract was
+  # validated against; the exact tested resolution is enforced on the
+  # workspace lockfile by tool/fortal_parity/check.dart, which also requires
+  # both published packages to carry this identical constraint.
   naked_ui: ^1.0.0-beta.14
 
 dev_dependencies:

--- a/packages/remix/pubspec.yaml
+++ b/packages/remix/pubspec.yaml
@@ -27,7 +27,12 @@ dependencies:
     sdk: flutter
   mix: ^2.2.0-beta.5
   mix_annotations: ^2.2.0-beta.1
-  naked_ui: 1.0.0-beta.14
+  # Ranged, not pinned: pub.dev rejects an exact hosted constraint with
+  # "your dependency should allow more than one version" and the publish
+  # exits 65. beta.14 is the current latest, so this resolves identically
+  # today; it only stops the constraint fighting other packages that also
+  # depend on naked_ui.
+  naked_ui: ^1.0.0-beta.14
 
 dev_dependencies:
   flutter_test:

--- a/packages/remix_fortal/pubspec.yaml
+++ b/packages/remix_fortal/pubspec.yaml
@@ -43,9 +43,10 @@ dependencies:
   mix_chart: ^0.0.1-beta.1
   # Ranged, not pinned: pub.dev rejects an exact hosted constraint with
   # "your dependency should allow more than one version" and the publish
-  # exits 65. beta.14 is the current latest, so this resolves identically
-  # today; it only stops the constraint fighting other packages that also
-  # depend on naked_ui.
+  # exits 65. The floor is the release the Fortal parity contract was
+  # validated against; the exact tested resolution is enforced on the
+  # workspace lockfile by tool/fortal_parity/check.dart, which also requires
+  # both published packages to carry this identical constraint.
   naked_ui: ^1.0.0-beta.14
 
 dev_dependencies:

--- a/packages/remix_fortal/pubspec.yaml
+++ b/packages/remix_fortal/pubspec.yaml
@@ -41,7 +41,12 @@ dependencies:
   mix: ^2.2.0-beta.5
   mix_annotations: ^2.2.0-beta.1
   mix_chart: ^0.0.1-beta.1
-  naked_ui: 1.0.0-beta.14
+  # Ranged, not pinned: pub.dev rejects an exact hosted constraint with
+  # "your dependency should allow more than one version" and the publish
+  # exits 65. beta.14 is the current latest, so this resolves identically
+  # today; it only stops the constraint fighting other packages that also
+  # depend on naked_ui.
+  naked_ui: ^1.0.0-beta.14
 
 dev_dependencies:
   flutter_test:

--- a/packages/remix_fortal/tool/fortal_parity/check.dart
+++ b/packages/remix_fortal/tool/fortal_parity/check.dart
@@ -5,7 +5,17 @@ import 'dart:typed_data';
 const _expectedIntegrity =
     'sha512-I0/h2CRNTpYNB7Mi3xFIvSsQq5a108d7kK8dTO5zp5b9HR5QJXKag6B8tjpz2ITkVYkFdkGk45doNkSr7OxwNw==';
 const _expectedNakedUiVersion = '1.0.0-beta.14';
-const _expectedNakedUiConstraint = '1.0.0-beta.14';
+
+/// A range, not the exact version, because these are two different guarantees
+/// enforced in two different places. The parity contract is validated against
+/// exactly [_expectedNakedUiVersion], and the *lockfile* check below is what
+/// pins that: the workspace must resolve it hosted, byte-exact. The pubspec
+/// constraint is the consumer surface, and pub.dev refuses to publish an exact
+/// hosted constraint ("your dependency should allow more than one version",
+/// exit 65) — an exact pin here made the v1.0.0-beta.7 publish impossible.
+/// The floor still names the tested release; both packages must carry this
+/// identical string.
+const _expectedNakedUiConstraint = '^1.0.0-beta.14';
 const _expectedMappedFamilies = <String>{
   'avatar',
   'badge',
@@ -992,7 +1002,9 @@ void _checkNakedPin(
   File workspaceLock,
   List<String> failures,
 ) {
-  // Both publishable packages must use the same exact hosted release.
+  // Both publishable packages must carry the identical hosted constraint,
+  // whose floor is the release the parity contract was validated against.
+  // The exact tested resolution is enforced on the lockfile below, not here.
   final pinned = RegExp(
     '^  naked_ui: ${RegExp.escape(_expectedNakedUiConstraint)}\\s*\$',
     multiLine: true,


### PR DESCRIPTION
The `v1.0.0-beta.7` publish run ([log](https://github.com/conceptadev/remix/actions/runs/33205661906)) failed validation before uploading anything, so **nothing was published**:

```
* Your dependency on "naked_ui" should allow more than one version.
Package has 1 warning.
Process completed with exit code 65
```

Both published packages carried `naked_ui: 1.0.0-beta.14` — an exact hosted constraint, which pub.dev refuses. `remix_fortal` would have failed identically at the second tag.

## The pin was a decision, and the contract was self-contradictory

The first version of this PR called the dropped caret in #164 an accident. CI corrected that: `tool/fortal_parity/check.dart` *enforces* the exact pin, so it was deliberate — the parity contract names the exact release it was validated against.

But that contract wants two different guarantees, and only one belongs in a pubspec:

- **"The repo tests against exactly beta.14"** — already enforced by the checker's own *lockfile* rule (workspace must resolve `naked_ui 1.0.0-beta.14`, hosted, byte-exact). Unchanged.
- **"Consumers get a compatible naked_ui"** — the pubspec constraint, which pub.dev refuses to publish as an exact pin.

As written, the contract made publishing impossible: the checker demanded the pin, the registry rejected it. Nobody hit this before because the pin postdates the beta.6 release.

## Change

- Checker: `_expectedNakedUiConstraint` becomes `^1.0.0-beta.14`, with a comment explaining the two-guarantee split. Both packages must still carry the identical string; the floor still names the validated release; the lockfile rule keeps pinning what the repo actually tests.
- Both pubspecs: `naked_ui: ^1.0.0-beta.14`, comment pointing at where the exact pin lives now.

`naked_ui`'s current latest **is** beta.14, so resolution is identical today.

## Verification

- Fortal parity check passes: `hosted Naked 1.0.0-beta.14 resolution` verified
- Workspace lockfile still resolves exactly `1.0.0-beta.14` hosted
- `dart pub publish --dry-run`: **0 warnings** on both packages

## After merge

The `v1.0.0-beta.7` tag currently points at the release commit that cannot publish. It needs moving to this fix before the publish is retried. No version bump needed — beta.7 was never served.