### PR TITLE
ci(remix_icons): automate pub.dev releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,17 @@
 name: Publish to pub.dev
 
-# Two tag-gated jobs rather than one job listing both packages: the reusable
+# Three tag-gated jobs rather than one job listing all packages: the reusable
 # publish workflow turns `packages:` into a parallel matrix with no ordering
-# knob, and `remix_fortal` depends on a hosted `remix`, so a single job would
-# race.
+# knob, and `remix_fortal` depends on hosted `remix` and `remix_icons`
+# versions, so a single job would race.
 #
-# THE TWO PACKAGES PUBLISH FROM DIFFERENT TAG PATTERNS. This is not a style
+# THE THREE PACKAGES PUBLISH FROM DIFFERENT TAG PATTERNS. This is not a style
 # choice — it is each package's "Automated publishing" tag pattern on pub.dev,
 # and the OIDC token is rejected if the pushed tag does not match:
 #
 #   remix          ->  v<version>               (bare, e.g. v1.0.0-beta.5)
 #   remix_fortal   ->  remix_fortal-v<version>
+#   remix_icons    ->  remix_icons-v<version>
 #
 # Pushing `remix-v<version>` therefore does NOT publish remix. It fails
 # authentication with "this token has 'refs/tags/remix-v...' ref for which
@@ -34,6 +35,7 @@ on:
   push:
     tags:
       - 'remix_fortal-v[0-9]+.[0-9]+.[0-9]+*'
+      - 'remix_icons-v[0-9]+.[0-9]+.[0-9]+*'
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
@@ -55,6 +57,16 @@ jobs:
     with:
       packages_folder_path: "packages"
       packages: "remix_fortal"
+    permissions:
+      id-token: write
+      contents: read
+
+  publish-remix-icons:
+    if: startsWith(github.ref, 'refs/tags/remix_icons-v')
+    uses: conceptadev/dart-actions/.github/workflows/publish.yml@9075ce1232ec77b8747953f2ff4a349190e5a805
+    with:
+      packages_folder_path: "packages"
+      packages: "remix_icons"
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Description

Adds `remix_icons-v<version>` as a dedicated release path in the existing pub.dev workflow. Matching tags publish only `packages/remix_icons` through the repository's pinned OIDC-enabled reusable workflow, without coupling the independently versioned icon package to the Remix/Fortal version-bump workflow.

The first `remix_icons` version still has to be published manually because pub.dev only permits automated publishing for an existing package. After `remix_icons` 0.1.0 exists and its pub.dev Admin settings authorize `conceptadev/remix` with tag pattern `remix_icons-v{{version}}`, future matching tags will publish automatically.

## Related Issues

None.

---

## Checklist

- [x] The changed workflow is statically validated and the existing `remix_icons` tests pass.
- [x] The release tag mapping is documented in the workflow.
- [x] I am prepared to follow up on review comments in a timely manner.

## Validation

- `actionlint .github/workflows/publish.yml`
- `fvm flutter test` in `packages/remix_icons` — 4 tests passed
- `fvm flutter pub publish --dry-run` in `packages/remix_icons` — 0 warnings
- `git diff --check`

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Rollout

Do not push a `remix_icons-v*` tag until version 0.1.0 has been published manually and automated publishing is enabled on pub.dev. If pub.dev is configured to require a GitHub Actions environment, use `Production` to match the pinned reusable workflow.
