### PR TITLE
fix(data_list): bound minimum intrinsic width by maximum

### DIFF
--- a/packages/remix/lib/src/components/data_list/data_list_widget.dart
+++ b/packages/remix/lib/src/components/data_list/data_list_widget.dart
@@ -477,7 +477,10 @@ class _RenderBreakableDataListValue extends RenderProxyBox {
     }
     painter.dispose();
 
-    return widestCluster;
+    // Selection boxes and paragraph intrinsics can differ by floating-point
+    // rounding. A minimum must never exceed the child's maximum width.
+    final maximum = super.computeMaxIntrinsicWidth(height);
+    return widestCluster > maximum ? maximum : widestCluster;
   }
 
   static RenderParagraph? _findParagraph(RenderObject? root) {

--- a/packages/remix_fortal/test/components/data_list/data_list_fortal_parity_test.dart
+++ b/packages/remix_fortal/test/components/data_list/data_list_fortal_parity_test.dart
@@ -4,6 +4,32 @@ import 'package:remix/remix.dart';
 import 'package:remix_fortal/remix_fortal.dart';
 
 void main() {
+  for (final value in ['1', '2', 'true', 'colors/fortal.accent.9']) {
+    testWidgets(
+      'horizontal single-value layout preserves intrinsic bounds: $value',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            builder: (_, child) => FortalScope(child: child!),
+            home: Center(
+              child: SizedBox(
+                width: 500,
+                child: FortalDataList(
+                  size: .size1,
+                  items: [
+                    RemixDataListItem(label: 'Declared value', value: value),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+        expect(tester.takeException(), isNull);
+        expect(find.text(value), findsOneWidget);
+      },
+    );
+  }
+
   for (final (size, fontSize, rowSpacing) in const [
     (FortalDataListSize.size1, 12.0, 12.0),
     (FortalDataListSize.size2, 14.0, 16.0),


### PR DESCRIPTION
## Description

Single-digit values such as `1` and `2` in a size-1 `FortalDataList` can fail Flutter's `maxIntrinsicWidth >= minIntrinsicWidth` assertion. Grapheme selection-box measurements can round slightly above the child's maximum paragraph width. Bound the reported minimum by that maximum so these values render while preserving grapheme wrapping for longer text.

## Related Issues

Closes #184

## Validation

Using Flutter 3.44.0:

- New regression cases for `1` and `2` reproduced the assertion before the fix and pass afterward; `true` and `colors/fortal.accent.9` are passing controls.
- `cd packages/remix && fvm flutter test --no-pub test/components/data_list --reporter expanded` — 110 passed, including existing grapheme, RTL, and text-scale coverage.
- `cd packages/remix_fortal && fvm flutter test --no-pub test/components/data_list/data_list_fortal_parity_test.dart --reporter expanded` — 9 passed.
- Targeted `dart analyze`, formatting, and `git diff --check` passed.

## Visual evidence

Pending: attach a standalone Data List reproduction screenshot. Browser capture/upload is currently unavailable; this PR remains a draft until the requested media is attached.

## Checklist

- [x] My PR includes unit or integration tests for all changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (the internal rounding constraint is documented inline; public API documentation is unchanged).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is not a breaking change.
