### PR TITLE
docs(fortal): clarify button icon sizing and overrides

### DIFF
--- a/docs/components/button.mdx
+++ b/docs/components/button.mdx
@@ -152,6 +152,50 @@ class FortalButtonExample extends StatelessWidget {
   See the [fortalButtonStyle source code](https://github.com/btwld/remix/blob/main/packages/remix_fortal/lib/src/recipes/button.dart) for all available options.
 </Info>
 
+### Fortal button icon sizing
+
+`FortalButton.size` selects the button's layout and label metrics, but does not
+set the size of its leading or trailing icons. The default icon builders inherit
+the surrounding Flutter `IconTheme` size; Flutter falls back to 24 logical pixels
+when no icon size is supplied. A small button can therefore still contain a
+24-pixel icon.
+
+Use `IconTheme(data: IconThemeData(size: 14), child: FortalButton.soft(...))`
+to set the inherited size for a subtree. For an explicit per-button override,
+pass a Fortal recipe to `RemixButton` and customize its icon styler.
+`FortalButton` itself has no `style` parameter.
+
+<CodeGroup title="Explicit Fortal icon size" defaultLanguage="dart">
+```dart
+import 'package:flutter/material.dart';
+import 'package:remix/remix.dart';
+import 'package:remix_fortal/remix_fortal.dart';
+
+class FortalButtonIconSizeExample extends StatelessWidget {
+  const FortalButtonIconSizeExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return FortalScope(
+      child: RemixButton(
+        label: 'Save',
+        leadingIcon: Icons.save,
+        trailingIcon: Icons.check,
+        onPressed: () {},
+        style: fortalButtonStyle(variant: .soft, size: .size1)
+            .icon(IconStyler().size(14)),
+      ),
+    );
+  }
+}
+```
+</CodeGroup>
+
+The 14-pixel value is a caller choice, not a Fortal size preset. This override
+applies to both default icon slots. Custom `leadingIconBuilder` and
+`trailingIconBuilder` implementations receive the icon spec and are responsible
+for applying it to their own widgets.
+
 ## Constructor
 <CodeGroup title="Constructor" defaultLanguage="dart">
 ```dart

--- a/packages/remix_fortal/test/components/button/button_icon_sizing_test.dart
+++ b/packages/remix_fortal/test/components/button/button_icon_sizing_test.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remix/remix.dart';
+import 'package:remix_fortal/remix_fortal.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  for (final variant in FortalButtonVariant.values) {
+    for (final size in FortalButtonSize.values) {
+      testWidgets('${variant.name}/${size.name} inherits icon size', (
+        tester,
+      ) async {
+        await tester.pumpRemixApp(
+          IconTheme(
+            data: const IconThemeData(size: 19),
+            child: FortalButton(
+              variant: variant,
+              size: size,
+              label: 'Save',
+              leadingIcon: Icons.save,
+              trailingIcon: Icons.check,
+              onPressed: () {},
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(tester.getSize(find.byIcon(Icons.save)), const Size.square(19));
+        expect(tester.getSize(find.byIcon(Icons.check)), const Size.square(19));
+        expect(tester.takeException(), isNull);
+      });
+
+      testWidgets('${variant.name}/${size.name} accepts recipe icon override', (
+        tester,
+      ) async {
+        var presses = 0;
+        await tester.pumpRemixApp(
+          IconTheme(
+            data: const IconThemeData(size: 19),
+            child: RemixButton(
+              style: fortalButtonStyle(
+                variant: variant,
+                size: size,
+              ).icon(IconStyler().size(14)),
+              label: 'Save',
+              leadingIcon: Icons.save,
+              trailingIcon: Icons.check,
+              onPressed: () => presses++,
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(tester.getSize(find.byIcon(Icons.save)), const Size.square(14));
+        expect(tester.getSize(find.byIcon(Icons.check)), const Size.square(14));
+        await tester.tap(find.text('Save'));
+        await tester.pumpAndSettle();
+        expect(presses, 1);
+        expect(tester.takeException(), isNull);
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Description

Explain why a small `FortalButton` can retain a 24-pixel icon: its default icon slots inherit `IconTheme`, independently of the button size preset. Document both inherited sizing and an explicit `RemixButton` + `fortalButtonStyle(...).icon(IconStyler().size(14))` example. The numeric override is a caller choice; runtime defaults are unchanged.

Add widget coverage for both default icon slots across all six variants and four sizes, checking inherited sizing, explicit overrides, and activation.

## Related Issues

Closes #186.

## Validation

- `fvm flutter test --no-pub test/components/button --reporter=expanded` (from `packages/remix_fortal`) — 61 tests passed.
- `fvm dart tool/validate_docs.dart` — 137 Dart examples analyzed successfully, including the new example; 8 examples explicitly skipped.
- `fvm dart analyze packages/remix_fortal/test/components/button/button_icon_sizing_test.dart` — no issues.
- Formatting and `git diff --check` — passed.

## Visual evidence

Standalone screenshot pending; the documented example is executable and widget-tested. This PR is a draft while the requested media is unavailable.

## Checklist

- [x] My PR includes unit or integration tests for all changed/updated/fixed behaviors (existing sizing behavior is covered; no runtime behavior changes).
- [x] I have updated or added relevant documentation (Button guide and analyzable example).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is not a breaking change.
