### PR TITLE
fix(ci): publish with the pinned Flutter SDK

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,35 +38,40 @@ on:
       - 'remix_ui_icons-v[0-9]+.[0-9]+.[0-9]+*'
       - 'v[0-9]+.[0-9]+.[0-9]+*'
 
+# Match the SDK used by version preparation and local validation. Floating to
+# latest stable can fail before package resolution even when the release passed CI.
 jobs:
   publish-remix:
     # Bare `v*` only. `refs/tags/remix_fortal-v...` does not start with
     # `refs/tags/v`, so the two conditions stay mutually exclusive.
     if: startsWith(github.ref, 'refs/tags/v')
-    uses: conceptadev/dart-actions/.github/workflows/publish.yml@9075ce1232ec77b8747953f2ff4a349190e5a805
+    uses: conceptadev/dart-actions/.github/workflows/publish.yml@c698e90da642bb20325fbd50ef4e40988a8ff83d
     with:
       packages_folder_path: "packages"
       packages: "remix"
+      flutter_version_file: ".fvmrc"
     permissions:
       id-token: write
       contents: read
 
   publish-remix-fortal:
     if: startsWith(github.ref, 'refs/tags/remix_fortal-v')
-    uses: conceptadev/dart-actions/.github/workflows/publish.yml@9075ce1232ec77b8747953f2ff4a349190e5a805
+    uses: conceptadev/dart-actions/.github/workflows/publish.yml@c698e90da642bb20325fbd50ef4e40988a8ff83d
     with:
       packages_folder_path: "packages"
       packages: "remix_fortal"
+      flutter_version_file: ".fvmrc"
     permissions:
       id-token: write
       contents: read
 
   publish-remix-ui-icons:
     if: startsWith(github.ref, 'refs/tags/remix_ui_icons-v')
-    uses: conceptadev/dart-actions/.github/workflows/publish.yml@9075ce1232ec77b8747953f2ff4a349190e5a805
+    uses: conceptadev/dart-actions/.github/workflows/publish.yml@c698e90da642bb20325fbd50ef4e40988a8ff83d
     with:
       packages_folder_path: "packages"
       packages: "remix_ui_icons"
+      flutter_version_file: ".fvmrc"
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Description

Publish with the Flutter SDK in `.fvmrc` (3.44.0), matching the tested release toolchain. The beta.9 publish run selected floating stable Flutter 3.47.3 and failed to resolve Flutter's own `test 1.31.1` dependency before uploading any package.

Pin the shared publisher to `c698e90da642bb20325fbd50ef4e40988a8ff83d`, which adds the optional version-file input in conceptadev/dart-actions#6. This also includes its existing fix to restore committed files after Flutter migrations before publishing. Keep the existing tag patterns, package ordering, Production environment, and OIDC permissions.

## Related Issues

Release follow-up to #188. [Failed publish run](https://github.com/conceptadev/remix/actions/runs/34513860755).

## Validation

- `actionlint .github/workflows/publish.yml` and `git diff --check` passed.
- Shared publisher CodeQL checks passed before conceptadev/dart-actions#6 was merged.
- Both packages and changelogs are byte-identical to the validated beta.9 release commit; only `.github/workflows/publish.yml` changes.
- The release commit passed full CI, 180 focused local tests, documentation validation, and zero-warning publish dry runs with Flutter 3.44.0.

## Checklist

- [x] My PR includes unit or integration tests for all changed/updated/fixed behaviors (workflow validation; package behavior is unchanged).
- [x] I have updated or added relevant documentation (workflow explanation and shared input documentation).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is not a breaking change.
