### PR TITLE
fix(ci): provision publishing credentials after validation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
     # Bare `v*` only. `refs/tags/remix_fortal-v...` does not start with
     # `refs/tags/v`, so the two conditions stay mutually exclusive.
     if: startsWith(github.ref, 'refs/tags/v')
-    uses: conceptadev/dart-actions/.github/workflows/publish.yml@c698e90da642bb20325fbd50ef4e40988a8ff83d
+    uses: conceptadev/dart-actions/.github/workflows/publish.yml@743dea6a54cf8cd96272b740f5904fdbc698e9e5
     with:
       packages_folder_path: "packages"
       packages: "remix"
@@ -56,7 +56,7 @@ jobs:
 
   publish-remix-fortal:
     if: startsWith(github.ref, 'refs/tags/remix_fortal-v')
-    uses: conceptadev/dart-actions/.github/workflows/publish.yml@c698e90da642bb20325fbd50ef4e40988a8ff83d
+    uses: conceptadev/dart-actions/.github/workflows/publish.yml@743dea6a54cf8cd96272b740f5904fdbc698e9e5
     with:
       packages_folder_path: "packages"
       packages: "remix_fortal"
@@ -67,7 +67,7 @@ jobs:
 
   publish-remix-ui-icons:
     if: startsWith(github.ref, 'refs/tags/remix_ui_icons-v')
-    uses: conceptadev/dart-actions/.github/workflows/publish.yml@c698e90da642bb20325fbd50ef4e40988a8ff83d
+    uses: conceptadev/dart-actions/.github/workflows/publish.yml@743dea6a54cf8cd96272b740f5904fdbc698e9e5
     with:
       packages_folder_path: "packages"
       packages: "remix_ui_icons"


### PR DESCRIPTION
## Description

Advance the shared publisher pin to `743dea6a54cf8cd96272b740f5904fdbc698e9e5` from conceptadev/dart-actions#7. Dependency resolution, tests, and dry runs now finish before OIDC credentials are provisioned. The publishing Dart SDK matches the version bundled in the selected Flutter SDK.

This addresses the repeated HTTP 403 during dependency resolution in the beta.9 publish run. Package contents, changelogs, version-file selection, tag patterns, and publication order are unchanged.

## Related Issues

Release follow-up to #188 and #189. [Failed publish run](https://github.com/conceptadev/remix/actions/runs/34514669453).

## Validation

- `actionlint .github/workflows/publish.yml` and `git diff --check` passed.
- Shared publisher CodeQL checks passed before merge.
- The diff only updates three references to the shared publisher; package source and release metadata match the validated beta.9 release.

## Checklist

- [x] My PR includes unit or integration tests for all changed/updated/fixed behaviors (workflow validation; package behavior is unchanged).
- [x] I have updated or added relevant documentation (shared publisher documentation).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is not a breaking change.
