### PR TITLE
fix(fortal): preserve Kbd token font families

### DIFF
--- a/packages/remix_fortal/lib/src/recipes/kbd.dart
+++ b/packages/remix_fortal/lib/src/recipes/kbd.dart
@@ -15,6 +15,8 @@ enum FortalKbdVariant { classic, soft }
 /// upstream's unsized `0.75em` — anchored to the root `text3` token rather
 /// than the ambient `DefaultTextStyle`, so a host text run cannot resize the
 /// key cap.
+/// The resolved token supplies the font family and fallback families; Kbd
+/// retains its own weight, spacing, and line box.
 BadgeStyler fortalKbdStyle(
   BuildContext context, {
   FortalTextSize? size,
@@ -31,6 +33,12 @@ BadgeStyler fortalKbdStyle(
   // Kbd pins its own weight and line box regardless of the surrounding style,
   // so it stays a key cap rather than following surrounding copy.
   final textStyle = TextStyler()
+      .style(
+        TextStyleMix(
+          fontFamily: base.fontFamily,
+          fontFamilyFallback: base.fontFamilyFallback,
+        ),
+      )
       .fontSize(fontSize)
       .fontWeight(FortalTokens.fontWeightRegular())
       .height(1.7)

--- a/packages/remix_fortal/test/components/typography/typography_test.dart
+++ b/packages/remix_fortal/test/components/typography/typography_test.dart
@@ -12,6 +12,40 @@ import '../../helpers/test_helpers.dart';
 
 void main() {
   group('metrics', () {
+    for (final variant in FortalKbdVariant.values) {
+      testWidgets('kbd ${variant.name} preserves token font families', (
+        tester,
+      ) async {
+        for (final size in [null, FortalTextSize.size2]) {
+          final token = size == null ? FortalTokens.text3 : FortalTokens.text2;
+          await _pump(
+            tester,
+            Builder(
+              builder: (context) => MixScope.inherit(
+                textStyles: {
+                  token: token
+                      .resolve(context)
+                      .copyWith(
+                        fontFamily: 'Custom family',
+                        fontFamilyFallback: ['Fallback family'],
+                      ),
+                },
+                child: FortalKbd('Key', variant: variant, size: size),
+              ),
+            ),
+            ambient: const TextStyle(fontFamily: 'Unrelated ambient family'),
+          );
+          final style = _renderedTextStyle(tester, 'Key');
+          expect(style.fontFamily, 'Custom family');
+          expect(style.fontFamilyFallback, ['Fallback family']);
+          expect(style.inherit, isFalse);
+          expect(style.fontWeight, FontWeight.w400);
+          expect(style.fontSize, closeTo(size == null ? 12 : 11.2, 1e-9));
+          expect(style.height, 1.7);
+        }
+      });
+    }
+
     testWidgets('all nine sizes resolve the pinned scale across scaling', (
       tester,
     ) async {


### PR DESCRIPTION
## Description

Preserve the font family and fallback families from Kbd's resolved Fortal text token. Previously Kbd copied the token's metrics but dropped its font families, so custom theme typography did not reach the rendered keycap.

Kbd keeps its existing size factors, weight, spacing, colors, line box, and isolation from ambient text styles. Unconfigured token families remain unchanged.

## Related Issues

No existing issue; the regression is included in this PR.

## Validation

- New classic/soft regressions failed with expected custom family versus null before the fix; both pass afterward, covering unsized and explicit-size tokens and fallback families.
- `fvm flutter test --no-pub test/components/typography/typography_test.dart` — 44 passed.
- Full `remix_fortal` test suite — 458 passed.
- Targeted analysis, formatting, and `git diff --check` passed.
- CI passed for build, icons, PR title, and all-package tests at `b895a37`; deployment was skipped.
- Adversarial review found no confirmed correctness regression or weakened existing tests. Custom fonts may intentionally change glyph widths; actual font loading and appearance remain subject to the visual check below.

## Visual evidence

Pending a standalone custom-font screenshot. This PR remains a draft until visual evidence is attached; rendered text-style assertions verify font selection, not glyph coverage for every font.

## Checklist

- [x] My PR includes unit or integration tests for all changed behaviors.
- [x] I have updated relevant documentation in the recipe doc comment.
- [x] I am prepared to follow up on review comments.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is not a breaking change.
