### PR TITLE
fix(fortal)!: size button icons from preset tokens

### DIFF
--- a/docs/components/button.mdx
+++ b/docs/components/button.mdx
@@ -154,16 +154,16 @@ class FortalButtonExample extends StatelessWidget {
 
 ### Fortal button icon sizing
 
-`FortalButton.size` selects the button's layout and label metrics, but does not
-set the size of its leading or trailing icons. The default icon builders inherit
-the surrounding Flutter `IconTheme` size; Flutter falls back to 24 logical pixels
-when no icon size is supplied. A small button can therefore still contain a
-24-pixel icon.
+`FortalButton.size` selects layout, label and default icon dimensions. Leading
+and trailing icons share Fortal IconButton's token-based size scale:
+`space3`, `space4`, `spinnerSize3`, and `space5` for sizes 1 through 4.
+The surrounding `IconTheme` no longer determines their size. Base
+`RemixButton` remains theme-neutral and still supports inherited sizing.
 
-Use `IconTheme(data: IconThemeData(size: 14), child: FortalButton.soft(...))`
-to set the inherited size for a subtree. For an explicit per-button override,
-pass a Fortal recipe to `RemixButton` and customize its icon styler.
-`FortalButton` itself has no `style` parameter.
+For an explicit per-button override, customize the icon styler through
+`FortalButton(style: ButtonStyler().icon(IconStyler().size(14)), ...)`, or pass
+a customized Fortal recipe to `RemixButton` as below. Applications previously
+depending on `IconTheme.size` for Fortal buttons should use an explicit override.
 
 <CodeGroup title="Explicit Fortal icon size" defaultLanguage="dart">
 ```dart

--- a/packages/remix_cli/lib/src/registry/fortal/templates/base_button/base_button.dart.tmpl
+++ b/packages/remix_cli/lib/src/registry/fortal/templates/base_button/base_button.dart.tmpl
@@ -55,6 +55,14 @@ enum {{typePrefix}}BaseButtonSize { size1, size2, size3, size4 }
   ),
 };
 
+/// Default icon dimensions shared by text and icon-only button presets.
+double {{valuePrefix}}BaseButtonIconSize({{typePrefix}}BaseButtonSize size) => switch (size) {
+  .size1 => {{typePrefix}}Tokens.space3(),
+  .size2 => {{typePrefix}}Tokens.space4(),
+  .size3 => {{typePrefix}}Tokens.spinnerSize3(),
+  .size4 => {{typePrefix}}Tokens.space5(),
+};
+
 /// Content-box metrics for the ghost BaseButton variant.
 ({double paddingX, double paddingY, double marginX, double marginY, double gap})
 {{valuePrefix}}BaseButtonGhostMetrics({{typePrefix}}BaseButtonSize size) => switch (size) {

--- a/packages/remix_cli/lib/src/registry/fortal/templates/button/button.dart.tmpl
+++ b/packages/remix_cli/lib/src/registry/fortal/templates/button/button.dart.tmpl
@@ -14,6 +14,9 @@ enum {{typePrefix}}ButtonSize { size1, size2, size3, size4 }
 enum {{typePrefix}}ButtonVariant { classic, solid, soft, surface, outline, ghost }
 
 /// {{typePrefix}}-themed Button with the Radix size, variant, and override contract.
+///
+/// Default icon slots use the preset's icon size, not the ambient IconTheme.
+/// An explicit icon size in [style] overrides that default.
 @MixWidget(target: RemixButton.new)
 ButtonStyler {{valuePrefix}}ButtonStyle({
   {{typePrefix}}ButtonVariant variant = .solid,
@@ -40,6 +43,7 @@ ButtonStyler _{{valuePrefix}}ButtonBaseStyler(
 ) {
   final metrics = {{valuePrefix}}BaseButtonMetrics(size);
   var style = ButtonStyler(
+    icon: .size({{valuePrefix}}BaseButtonIconSize(size)),
     container: .direction(.horizontal).mainAxisSize(.min).spacing(metrics.gap),
     label: .style(metrics.text.mix()).fontWeight(
       variant == .ghost

--- a/packages/remix_cli/lib/src/registry/fortal/templates/icon_button/icon_button.dart.tmpl
+++ b/packages/remix_cli/lib/src/registry/fortal/templates/icon_button/icon_button.dart.tmpl
@@ -43,7 +43,7 @@ IconButtonStyler _{{valuePrefix}}IconButtonBaseStyler(
 ) {
   final metrics = {{valuePrefix}}BaseButtonMetrics(size);
   var style = IconButtonStyler(
-    icon: .size(_{{valuePrefix}}IconButtonIconSize(size)),
+    icon: .size({{valuePrefix}}BaseButtonIconSize(size)),
     spinner: .size(metrics.spinnerSize)
         .opacity(0.65)
         .leafRadius({{typePrefix}}Tokens.radius1())
@@ -61,13 +61,6 @@ IconButtonStyler _{{valuePrefix}}IconButtonBaseStyler(
   }
   return style;
 }
-
-double _{{valuePrefix}}IconButtonIconSize({{typePrefix}}BaseButtonSize size) => switch (size) {
-  .size1 => {{typePrefix}}Tokens.space3(),
-  .size2 => {{typePrefix}}Tokens.space4(),
-  .size3 => {{typePrefix}}Tokens.spinnerSize3(),
-  .size4 => {{typePrefix}}Tokens.space5(),
-};
 
 {{typePrefix}}BaseButtonVariant _{{valuePrefix}}BaseButtonVariant(
   {{typePrefix}}IconButtonVariant variant,

--- a/packages/remix_fortal/lib/src/components/base_button.dart
+++ b/packages/remix_fortal/lib/src/components/base_button.dart
@@ -55,6 +55,14 @@ fortalBaseButtonMetrics(FortalBaseButtonSize size) => switch (size) {
   ),
 };
 
+/// Default icon dimensions shared by text and icon-only button presets.
+double fortalBaseButtonIconSize(FortalBaseButtonSize size) => switch (size) {
+  .size1 => FortalTokens.space3(),
+  .size2 => FortalTokens.space4(),
+  .size3 => FortalTokens.spinnerSize3(),
+  .size4 => FortalTokens.space5(),
+};
+
 /// Content-box metrics for the ghost BaseButton variant.
 ({double paddingX, double paddingY, double marginX, double marginY, double gap})
 fortalBaseButtonGhostMetrics(FortalBaseButtonSize size) => switch (size) {

--- a/packages/remix_fortal/lib/src/components/button.dart
+++ b/packages/remix_fortal/lib/src/components/button.dart
@@ -14,6 +14,9 @@ enum FortalButtonSize { size1, size2, size3, size4 }
 enum FortalButtonVariant { classic, solid, soft, surface, outline, ghost }
 
 /// Fortal-themed Button with the Radix size, variant, and override contract.
+///
+/// Default icon slots use the preset's icon size, not the ambient IconTheme.
+/// An explicit icon size in [style] overrides that default.
 @MixWidget(target: RemixButton.new)
 ButtonStyler fortalButtonStyle({
   FortalButtonVariant variant = .solid,
@@ -40,6 +43,7 @@ ButtonStyler _fortalButtonBaseStyler(
 ) {
   final metrics = fortalBaseButtonMetrics(size);
   var style = ButtonStyler(
+    icon: .size(fortalBaseButtonIconSize(size)),
     container: .direction(.horizontal).mainAxisSize(.min).spacing(metrics.gap),
     label: .style(metrics.text.mix()).fontWeight(
       variant == .ghost

--- a/packages/remix_fortal/lib/src/components/button.g.dart
+++ b/packages/remix_fortal/lib/src/components/button.g.dart
@@ -7,6 +7,9 @@ part of 'button.dart';
 // **************************************************************************
 
 /// Fortal-themed Button with the Radix size, variant, and override contract.
+///
+/// Default icon slots use the preset's icon size, not the ambient IconTheme.
+/// An explicit icon size in [style] overrides that default.
 class FortalButton extends StatelessWidget {
   const FortalButton({
     super.key,

--- a/packages/remix_fortal/lib/src/components/icon_button.dart
+++ b/packages/remix_fortal/lib/src/components/icon_button.dart
@@ -43,7 +43,7 @@ IconButtonStyler _fortalIconButtonBaseStyler(
 ) {
   final metrics = fortalBaseButtonMetrics(size);
   var style = IconButtonStyler(
-    icon: .size(_fortalIconButtonIconSize(size)),
+    icon: .size(fortalBaseButtonIconSize(size)),
     spinner: .size(metrics.spinnerSize)
         .opacity(0.65)
         .leafRadius(FortalTokens.radius1())
@@ -61,13 +61,6 @@ IconButtonStyler _fortalIconButtonBaseStyler(
   }
   return style;
 }
-
-double _fortalIconButtonIconSize(FortalBaseButtonSize size) => switch (size) {
-  .size1 => FortalTokens.space3(),
-  .size2 => FortalTokens.space4(),
-  .size3 => FortalTokens.spinnerSize3(),
-  .size4 => FortalTokens.space5(),
-};
 
 FortalBaseButtonVariant _fortalBaseButtonVariant(
   FortalIconButtonVariant variant,

--- a/packages/remix_fortal/test/components/button/button_icon_sizing_test.dart
+++ b/packages/remix_fortal/test/components/button/button_icon_sizing_test.dart
@@ -8,12 +8,18 @@ import '../../helpers/test_helpers.dart';
 void main() {
   for (final variant in FortalButtonVariant.values) {
     for (final size in FortalButtonSize.values) {
-      testWidgets('${variant.name}/${size.name} inherits icon size', (
+      testWidgets('${variant.name}/${size.name} uses preset icon size', (
         tester,
       ) async {
+        final expectedSize = switch (size) {
+          FortalButtonSize.size1 => 12.0,
+          FortalButtonSize.size2 => 16.0,
+          FortalButtonSize.size3 => 20.0,
+          FortalButtonSize.size4 => 24.0,
+        };
         await tester.pumpRemixApp(
           IconTheme(
-            data: const IconThemeData(size: 19),
+            data: const IconThemeData(size: 48),
             child: FortalButton(
               variant: variant,
               size: size,
@@ -26,10 +32,60 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        expect(tester.getSize(find.byIcon(Icons.save)), const Size.square(19));
-        expect(tester.getSize(find.byIcon(Icons.check)), const Size.square(19));
+        expect(
+          tester.getSize(find.byIcon(Icons.save)),
+          Size.square(expectedSize),
+        );
+        expect(
+          tester.getSize(find.byIcon(Icons.check)),
+          Size.square(expectedSize),
+        );
         expect(tester.takeException(), isNull);
       });
+
+      for (final direction in TextDirection.values) {
+        for (final slots in ['leading', 'trailing', 'both']) {
+          testWidgets(
+            '${variant.name}/${size.name}/$slots/${direction.name} contains icons at large text',
+            (tester) async {
+              var presses = 0;
+              await tester.pumpRemixApp(
+                MediaQuery(
+                  data: const MediaQueryData(textScaler: TextScaler.linear(2)),
+                  child: SizedBox(
+                    width: 320,
+                    child: Center(
+                      child: FortalButton(
+                        variant: variant,
+                        size: size,
+                        label: 'Save',
+                        leadingIcon: slots == 'trailing' ? null : Icons.save,
+                        trailingIcon: slots == 'leading' ? null : Icons.check,
+                        onPressed: () => presses++,
+                      ),
+                    ),
+                  ),
+                ),
+                textDirection: direction,
+              );
+              await tester.pumpAndSettle();
+              final bounds = tester.getRect(find.byType(RemixButton));
+              for (final icon in [Icons.save, Icons.check]) {
+                final finder = find.byIcon(icon);
+                if (finder.evaluate().isEmpty) continue;
+                final rect = tester.getRect(finder);
+                expect(rect.left, greaterThanOrEqualTo(bounds.left));
+                expect(rect.right, lessThanOrEqualTo(bounds.right));
+                expect(rect.top, greaterThanOrEqualTo(bounds.top));
+                expect(rect.bottom, lessThanOrEqualTo(bounds.bottom));
+              }
+              await tester.tap(find.text('Save'));
+              expect(presses, 1);
+              expect(tester.takeException(), isNull);
+            },
+          );
+        }
+      }
 
       testWidgets('${variant.name}/${size.name} accepts recipe icon override', (
         tester,

--- a/packages/remix_fortal/test/components/button/button_icon_sizing_test.dart
+++ b/packages/remix_fortal/test/components/button/button_icon_sizing_test.dart
@@ -72,7 +72,11 @@ void main() {
               final bounds = tester.getRect(find.byType(RemixButton));
               for (final icon in [Icons.save, Icons.check]) {
                 final finder = find.byIcon(icon);
-                if (finder.evaluate().isEmpty) continue;
+                final expected = icon == Icons.save
+                    ? slots != 'trailing'
+                    : slots != 'leading';
+                expect(finder, expected ? findsOneWidget : findsNothing);
+                if (!expected) continue;
                 final rect = tester.getRect(finder);
                 expect(rect.left, greaterThanOrEqualTo(bounds.left));
                 expect(rect.right, lessThanOrEqualTo(bounds.right));
@@ -115,6 +119,41 @@ void main() {
         expect(presses, 1);
         expect(tester.takeException(), isNull);
       });
+
+      testWidgets('${variant.name}/${size.name} accepts widget icon override', (
+        tester,
+      ) async {
+        await tester.pumpRemixApp(
+          FortalButton(
+            variant: variant,
+            size: size,
+            style: ButtonStyler().icon(IconStyler().size(14)),
+            label: 'Save',
+            leadingIcon: Icons.save,
+            trailingIcon: Icons.check,
+            onPressed: () {},
+          ),
+        );
+        expect(tester.getSize(find.byIcon(Icons.save)), const Size.square(14));
+        expect(tester.getSize(find.byIcon(Icons.check)), const Size.square(14));
+        expect(tester.takeException(), isNull);
+      });
     }
   }
+
+  testWidgets('base RemixButton still inherits icon size', (tester) async {
+    await tester.pumpRemixApp(
+      IconTheme(
+        data: const IconThemeData(size: 19),
+        child: RemixButton(
+          label: 'Save',
+          leadingIcon: Icons.save,
+          trailingIcon: Icons.check,
+          onPressed: () {},
+        ),
+      ),
+    );
+    expect(tester.getSize(find.byIcon(Icons.save)), const Size.square(19));
+    expect(tester.getSize(find.byIcon(Icons.check)), const Size.square(19));
+  });
 }


### PR DESCRIPTION
## Description

Fortal text-button icons now follow the button-size preset instead of inheriting an unrelated ambient icon size. Reuse IconButton's existing token scale (12/16/20/24 logical pixels under the default theme); explicit recipe/style overrides still win. Base RemixButton behavior and IconButton sizing stay unchanged.

Update the authored Fortal source, regenerate the application-owned preset, and replace the old inheritance guidance. This is the behavioral follow-up to #187, which documented the previous defaults without changing them.

## Related Issues

Closes #186, reopened for the remaining visual-default concern.

## Validation

- `fvm flutter test --no-pub --reporter expanded` in `packages/remix_fortal` — 627 passed.
- Full Fortal package Dart analysis — no issues.
- `fvm dart ../../tool/check_generated.dart` in `packages/remix_fortal` — 31 artifacts reproduced byte-for-byte.
- `fvm dart run tool/build_fortal_preset.dart --check` — passed.
- `fvm dart tool/validate_docs.dart` — passed, including 139 analyzable Dart examples.
- Formatting and `git diff --check` — passed.

Coverage includes both default icon slots under a 48-pixel ambient icon theme, explicit recipe overrides, all four sizes/six variants, and leading/trailing/both icon containment and activation in LTR/RTL with 2× text at 320 pixels.

## Visual evidence and limits

[Before/after Flutter captures and review](https://github.com/conceptadev/remix/pull/193#issuecomment-5628226234) confirm the proportional improvement for smaller presets; size 4 is unchanged. These are identical standalone fixtures with real fonts, not Muse screenshots or retouched images. All 24 preset-size regressions fail with the production size line removed and pass with it restored. Tests additionally verify direct Fortal overrides and unchanged base Remix inheritance.

![Before: ambient icon sizes](https://github.com/user-attachments/assets/532e0294-c714-43ad-b9d3-f84dc1273011)
![After: size-derived icon defaults](https://github.com/user-attachments/assets/96a99648-8912-423d-b1d1-9a709feee42f)

The largest two-icon button with 2× text still overflows at 240 pixels; that broader constrained-content behavior is outside this sizing fix. This is not a full accessibility claim.

## Checklist

- [x] My PR includes unit or integration tests for all changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

- [x] Yes, this is a breaking change.
- [ ] No, this is not a breaking change.

Visual compatibility change: callers intentionally relying on ambient `IconTheme.size` for Fortal text buttons must pass an explicit icon-size style override. No call-site change is needed to accept the new preset defaults.
