### PR TITLE
fix(fortal)!: size select and segmented content icons

### DIFF
--- a/packages/remix_cli/lib/src/registry/fortal/templates/segmented_control/segmented_control.dart.tmpl
+++ b/packages/remix_cli/lib/src/registry/fortal/templates/segmented_control/segmented_control.dart.tmpl
@@ -49,6 +49,9 @@ enum {{typePrefix}}SegmentedControlVariant { surface, classic }
 
 /// {{typePrefix}} recipe for [RemixSegmentedControl].
 ///
+/// Content icons use size-matched 12/16/20 token defaults rather than the
+/// ambient icon size. Control and item styles may override these defaults.
+///
 /// Paints the selected item in place. It does not reproduce Radix's sliding
 /// indicator, duplicate-label crossfade, inactive separators, or max-content
 /// overflow. Changing an item's label with the selection can therefore cause a
@@ -99,7 +102,7 @@ SegmentedControlItemStyler _{{valuePrefix}}SegmentedControlItemStyle(
             .maxLines(1)
             .overflow(TextOverflow.ellipsis),
       )
-      .icon(IconStyler().color({{typePrefix}}Tokens.gray12()))
+      .icon(IconStyler().color({{typePrefix}}Tokens.gray12()).size(metrics.iconSize))
       .containerEffects(
         RemixBoxEffectsMix(
           behindContent: RemixBoxEffectLayerMix(),
@@ -194,6 +197,7 @@ class _{{typePrefix}}SegmentedControlMetrics {
     required this.radius,
     required this.text,
     required this.activeLetterSpacing,
+    required this.iconSize,
   });
 
   final double height;
@@ -202,6 +206,7 @@ class _{{typePrefix}}SegmentedControlMetrics {
   final Radius radius;
   final TextStyleToken text;
   final double activeLetterSpacing;
+  final double iconSize;
 }
 
 _{{typePrefix}}SegmentedControlMetrics _{{valuePrefix}}SegmentedControlMetrics(
@@ -214,6 +219,7 @@ _{{typePrefix}}SegmentedControlMetrics _{{valuePrefix}}SegmentedControlMetrics(
     radius: {{typePrefix}}Tokens.radius2OrFull(),
     text: {{typePrefix}}Tokens.text1,
     activeLetterSpacing: {{typePrefix}}Tokens.tabActiveLetterSpacing1(),
+    iconSize: {{typePrefix}}Tokens.space3(),
   ),
   .size2 => _{{typePrefix}}SegmentedControlMetrics(
     height: {{typePrefix}}Tokens.space6(),
@@ -222,6 +228,7 @@ _{{typePrefix}}SegmentedControlMetrics _{{valuePrefix}}SegmentedControlMetrics(
     radius: {{typePrefix}}Tokens.radius2OrFull(),
     text: {{typePrefix}}Tokens.text2,
     activeLetterSpacing: {{typePrefix}}Tokens.tabActiveLetterSpacing2(),
+    iconSize: {{typePrefix}}Tokens.space4(),
   ),
   .size3 => _{{typePrefix}}SegmentedControlMetrics(
     height: {{typePrefix}}Tokens.space7(),
@@ -232,5 +239,6 @@ _{{typePrefix}}SegmentedControlMetrics _{{valuePrefix}}SegmentedControlMetrics(
     // The pinned `-0.01em` is derived from the resolved size-3 text token so
     // it remains exact at every {{typePrefix}} scaling without adding an eighth token.
     activeLetterSpacing: _segmentedControlActiveLetterSpacing3(),
+    iconSize: {{typePrefix}}Tokens.spinnerSize3(),
   ),
 };

--- a/packages/remix_cli/lib/src/registry/fortal/templates/select/select.dart.tmpl
+++ b/packages/remix_cli/lib/src/registry/fortal/templates/select/select.dart.tmpl
@@ -13,6 +13,9 @@ enum {{typePrefix}}SelectSize { size1, size2, size3 }
 enum {{typePrefix}}SelectVariant { surface, soft, ghost }
 
 /// {{typePrefix}}-themed Select with Radix-owned trigger and content configuration.
+///
+/// Content icons use size-matched 12/16/20 token defaults rather than the
+/// ambient icon size. Override the trigger icon through [style] when needed.
 @MixWidget(target: RemixSelect.new)
 SelectStyler {{valuePrefix}}SelectStyle({
   {{typePrefix}}SelectVariant variant = .surface,
@@ -47,7 +50,13 @@ SelectTriggerStyler _{{valuePrefix}}SelectTriggerStyler(
       .placeholder(
         _{{valuePrefix}}SelectTriggerText(size, color: {{typePrefix}}Tokens.grayA10()),
       )
-      .icon(.color({{typePrefix}}Tokens.gray12()))
+      .icon(
+        .color({{typePrefix}}Tokens.gray12()).size(switch (size) {
+          .size1 => {{typePrefix}}Tokens.space3(),
+          .size2 => {{typePrefix}}Tokens.space4(),
+          .size3 => {{typePrefix}}Tokens.spinnerSize3(),
+        }),
+      )
       .indicator(.color({{typePrefix}}Tokens.gray12()).size(size == .size3 ? 11 : 9))
       .onFocusVisible(
         .containerEffects(

--- a/packages/remix_fortal/lib/src/components/segmented_control.dart
+++ b/packages/remix_fortal/lib/src/components/segmented_control.dart
@@ -49,6 +49,9 @@ enum FortalSegmentedControlVariant { surface, classic }
 
 /// Fortal recipe for [RemixSegmentedControl].
 ///
+/// Content icons use size-matched 12/16/20 token defaults rather than the
+/// ambient icon size. Control and item styles may override these defaults.
+///
 /// Paints the selected item in place. It does not reproduce Radix's sliding
 /// indicator, duplicate-label crossfade, inactive separators, or max-content
 /// overflow. Changing an item's label with the selection can therefore cause a
@@ -99,7 +102,7 @@ SegmentedControlItemStyler _fortalSegmentedControlItemStyle(
             .maxLines(1)
             .overflow(TextOverflow.ellipsis),
       )
-      .icon(IconStyler().color(FortalTokens.gray12()))
+      .icon(IconStyler().color(FortalTokens.gray12()).size(metrics.iconSize))
       .containerEffects(
         RemixBoxEffectsMix(
           behindContent: RemixBoxEffectLayerMix(),
@@ -194,6 +197,7 @@ class _FortalSegmentedControlMetrics {
     required this.radius,
     required this.text,
     required this.activeLetterSpacing,
+    required this.iconSize,
   });
 
   final double height;
@@ -202,6 +206,7 @@ class _FortalSegmentedControlMetrics {
   final Radius radius;
   final TextStyleToken text;
   final double activeLetterSpacing;
+  final double iconSize;
 }
 
 _FortalSegmentedControlMetrics _fortalSegmentedControlMetrics(
@@ -214,6 +219,7 @@ _FortalSegmentedControlMetrics _fortalSegmentedControlMetrics(
     radius: FortalTokens.radius2OrFull(),
     text: FortalTokens.text1,
     activeLetterSpacing: FortalTokens.tabActiveLetterSpacing1(),
+    iconSize: FortalTokens.space3(),
   ),
   .size2 => _FortalSegmentedControlMetrics(
     height: FortalTokens.space6(),
@@ -222,6 +228,7 @@ _FortalSegmentedControlMetrics _fortalSegmentedControlMetrics(
     radius: FortalTokens.radius2OrFull(),
     text: FortalTokens.text2,
     activeLetterSpacing: FortalTokens.tabActiveLetterSpacing2(),
+    iconSize: FortalTokens.space4(),
   ),
   .size3 => _FortalSegmentedControlMetrics(
     height: FortalTokens.space7(),
@@ -232,5 +239,6 @@ _FortalSegmentedControlMetrics _fortalSegmentedControlMetrics(
     // The pinned `-0.01em` is derived from the resolved size-3 text token so
     // it remains exact at every Fortal scaling without adding an eighth token.
     activeLetterSpacing: _segmentedControlActiveLetterSpacing3(),
+    iconSize: FortalTokens.spinnerSize3(),
   ),
 };

--- a/packages/remix_fortal/lib/src/components/segmented_control.g.dart
+++ b/packages/remix_fortal/lib/src/components/segmented_control.g.dart
@@ -8,6 +8,9 @@ part of 'segmented_control.dart';
 
 /// Fortal recipe for [RemixSegmentedControl].
 ///
+/// Content icons use size-matched 12/16/20 token defaults rather than the
+/// ambient icon size. Control and item styles may override these defaults.
+///
 /// Paints the selected item in place. It does not reproduce Radix's sliding
 /// indicator, duplicate-label crossfade, inactive separators, or max-content
 /// overflow. Changing an item's label with the selection can therefore cause a

--- a/packages/remix_fortal/lib/src/components/select.dart
+++ b/packages/remix_fortal/lib/src/components/select.dart
@@ -13,6 +13,9 @@ enum FortalSelectSize { size1, size2, size3 }
 enum FortalSelectVariant { surface, soft, ghost }
 
 /// Fortal-themed Select with Radix-owned trigger and content configuration.
+///
+/// Content icons use size-matched 12/16/20 token defaults rather than the
+/// ambient icon size. Override the trigger icon through [style] when needed.
 @MixWidget(target: RemixSelect.new)
 SelectStyler fortalSelectStyle({
   FortalSelectVariant variant = .surface,
@@ -47,7 +50,13 @@ SelectTriggerStyler _fortalSelectTriggerStyler(
       .placeholder(
         _fortalSelectTriggerText(size, color: FortalTokens.grayA10()),
       )
-      .icon(.color(FortalTokens.gray12()))
+      .icon(
+        .color(FortalTokens.gray12()).size(switch (size) {
+          .size1 => FortalTokens.space3(),
+          .size2 => FortalTokens.space4(),
+          .size3 => FortalTokens.spinnerSize3(),
+        }),
+      )
       .indicator(.color(FortalTokens.gray12()).size(size == .size3 ? 11 : 9))
       .onFocusVisible(
         .containerEffects(

--- a/packages/remix_fortal/lib/src/components/select.g.dart
+++ b/packages/remix_fortal/lib/src/components/select.g.dart
@@ -7,6 +7,9 @@ part of 'select.dart';
 // **************************************************************************
 
 /// Fortal-themed Select with Radix-owned trigger and content configuration.
+///
+/// Content icons use size-matched 12/16/20 token defaults rather than the
+/// ambient icon size. Override the trigger icon through [style] when needed.
 class FortalSelect<T> extends StatelessWidget {
   const FortalSelect({
     super.key,

--- a/packages/remix_fortal/test/fortal/control_icon_sizing_test.dart
+++ b/packages/remix_fortal/test/fortal/control_icon_sizing_test.dart
@@ -1,0 +1,224 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remix/remix.dart';
+import 'package:remix_fortal/remix_fortal.dart';
+
+import '../helpers/test_helpers.dart';
+
+void main() {
+  testWidgets('Select icon remains sized when opened and selection works', (
+    tester,
+  ) async {
+    String? selected;
+    await tester.pumpRemixApp(
+      FortalSelect<String>(
+        trigger: const RemixSelectTrigger(
+          placeholder: 'Choose',
+          icon: Icons.star,
+        ),
+        items: const [RemixSelectItem(value: 'a', label: 'Apple')],
+        onChanged: (value) => selected = value,
+      ),
+    );
+    await tester.tap(find.text('Choose'));
+    await tester.pumpAndSettle();
+    expect(tester.getSize(find.byIcon(Icons.star)), const Size.square(16));
+    await tester.tap(find.text('Apple'));
+    await tester.pumpAndSettle();
+    expect(selected, 'a');
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('Segmented item override wins and selection works', (
+    tester,
+  ) async {
+    String? selected;
+    await tester.pumpRemixApp(
+      FortalSegmentedControl<String>(
+        style: SegmentedControlStyler().item(
+          SegmentedControlItemStyler().icon(.size(14)),
+        ),
+        items: [
+          RemixSegmentedControlItem(
+            value: 'a',
+            label: 'Alpha',
+            icon: Icons.star,
+            style: SegmentedControlItemStyler().icon(.size(18)),
+          ),
+        ],
+        selectedValue: null,
+        onChanged: (value) => selected = value,
+      ),
+    );
+    expect(tester.getSize(find.byIcon(Icons.star)), const Size.square(18));
+    await tester.tap(find.text('Alpha'));
+    await tester.pumpAndSettle();
+    expect(selected, 'a');
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('Base Remix retains ambient icon sizing', (tester) async {
+    for (final widget in <Widget>[
+      RemixSelect<String>(
+        trigger: const RemixSelectTrigger(
+          placeholder: 'Choose',
+          icon: Icons.star,
+        ),
+        items: const [RemixSelectItem(value: 'a', label: 'Apple')],
+      ),
+      RemixSegmentedControl<String>(
+        items: const [
+          RemixSegmentedControlItem(
+            value: 'a',
+            label: 'Alpha',
+            icon: Icons.star,
+          ),
+        ],
+        selectedValue: null,
+        onChanged: (_) {},
+      ),
+    ]) {
+      await tester.pumpRemixApp(
+        IconTheme(data: const IconThemeData(size: 19), child: widget),
+      );
+      expect(tester.getSize(find.byIcon(Icons.star)), const Size.square(19));
+      expect(tester.takeException(), isNull);
+    }
+  });
+
+  testWidgets('Content icon tokens follow Fortal scaling', (tester) async {
+    for (final widget in <Widget>[
+      FortalSelect<String>(
+        trigger: const RemixSelectTrigger(
+          placeholder: 'Choose',
+          icon: Icons.star,
+        ),
+        items: const [RemixSelectItem(value: 'a', label: 'Apple')],
+      ),
+      FortalSegmentedControl<String>(
+        items: const [
+          RemixSegmentedControlItem(
+            value: 'a',
+            label: 'Alpha',
+            icon: Icons.star,
+          ),
+        ],
+        selectedValue: null,
+        onChanged: (_) {},
+      ),
+    ]) {
+      await tester.pumpRemixApp(
+        FortalScope(scaling: .percent110, child: widget),
+      );
+      expect(
+        tester.getSize(find.byIcon(Icons.star)).width,
+        closeTo(17.6, 1e-9),
+      );
+      expect(
+        tester.getSize(find.byIcon(Icons.star)).height,
+        closeTo(17.6, 1e-9),
+      );
+      expect(tester.takeException(), isNull);
+    }
+  });
+
+  for (final size in FortalSelectSize.values) {
+    for (final variant in FortalSelectVariant.values) {
+      for (final enabled in [true, false]) {
+        for (final direction in TextDirection.values) {
+          for (final override in [false, true]) {
+            testWidgets(
+              'Select ${size.name} $variant enabled=$enabled $direction override=$override',
+              (tester) async {
+                await tester.pumpRemixApp(
+                  IconTheme(
+                    data: const IconThemeData(size: 48),
+                    child: FortalSelect<String>(
+                      size: size,
+                      variant: variant,
+                      enabled: enabled,
+                      style: override
+                          ? SelectStyler().trigger(
+                              SelectTriggerStyler().icon(.size(14)),
+                            )
+                          : const SelectStyler.create(),
+                      trigger: const RemixSelectTrigger(
+                        placeholder: 'Choose',
+                        icon: Icons.star,
+                      ),
+                      items: const [
+                        RemixSelectItem(value: 'a', label: 'Apple'),
+                      ],
+                      onChanged: (_) {},
+                    ),
+                  ),
+                  textDirection: direction,
+                );
+                final icon = find.byIcon(Icons.star);
+                expect(icon, findsOneWidget);
+                final spec = tester.resolvedSpecOf<SelectTriggerSpec>(icon);
+                final expected = override
+                    ? 14.0
+                    : [12.0, 16.0, 20.0][size.index];
+                expect(spec.icon.spec.size, expected);
+                expect(tester.getSize(icon), Size.square(expected));
+                expect(tester.takeException(), isNull);
+              },
+            );
+          }
+        }
+      }
+    }
+  }
+  for (final size in FortalSegmentedControlSize.values) {
+    for (final variant in FortalSegmentedControlVariant.values) {
+      for (final enabled in [true, false]) {
+        for (final direction in TextDirection.values) {
+          for (final override in [false, true]) {
+            testWidgets(
+              'Segmented ${size.name} $variant enabled=$enabled $direction override=$override',
+              (tester) async {
+                await tester.pumpRemixApp(
+                  IconTheme(
+                    data: const IconThemeData(size: 48),
+                    child: FortalSegmentedControl<String>(
+                      size: size,
+                      variant: variant,
+                      enabled: enabled,
+                      style: override
+                          ? SegmentedControlStyler().item(
+                              SegmentedControlItemStyler().icon(.size(14)),
+                            )
+                          : const SegmentedControlStyler.create(),
+                      items: const [
+                        RemixSegmentedControlItem(
+                          value: 'a',
+                          label: 'Alpha',
+                          icon: Icons.star,
+                        ),
+                      ],
+                      selectedValue: 'a',
+                      onChanged: (_) {},
+                    ),
+                  ),
+                  textDirection: direction,
+                );
+                final icon = find.byIcon(Icons.star);
+                expect(icon, findsOneWidget);
+                final spec = tester.resolvedSpecOf<SegmentedControlItemSpec>(
+                  icon,
+                );
+                final expected = override
+                    ? 14.0
+                    : [12.0, 16.0, 20.0][size.index];
+                expect(spec.icon.spec.size, expected);
+                expect(tester.getSize(icon), Size.square(expected));
+                expect(tester.takeException(), isNull);
+              },
+            );
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Select trigger icons and SegmentedControl item icons inherited ambient sizes,
leaving small presets with disproportionately large icons. Use Fortal's existing
12/16/20 token scale for their content icons. Explicit control/item overrides
still win; base Remix and Select indicator glyph sizing are unchanged.

## Related Issues

Follow-up to #193's component audit; no additional issue is closed.

## Validation

- 124 focused widget tests passed: sizes, variants, disabled states, RTL/LTR,
  overrides, selection callbacks, scaling and base Remix inheritance.
- Full Fortal suite: 582 tests passed on this independent main-based branch.
- Package analysis, regenerated CLI template check and `git diff --check` passed.
- Actual Flutter before/after captures reviewed and attached below.
- Exact-head CI passed, including the complete package test job and Windows CLI check.

## Visual evidence

Same 900×430
Flutter fixture, real fonts, default ambient 24px icons; no image retouching.
This does not claim arbitrary-width layout or full accessibility coverage.

Before:
![Before: ambient icons remain large in small controls](https://github.com/user-attachments/assets/00536f4c-f883-4552-8e45-5c3fb0e9b956)

After:
![After: icons follow the control size](https://github.com/user-attachments/assets/afb11969-8e91-4489-8ece-f1b7ee61266b)

## Checklist

- [x] My PR includes unit or integration tests for all changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

- [x] Yes, this is a breaking change.
- [ ] No, this is not a breaking change.

Visual defaults change for consumers relying on ambient icon sizes. Set
`SelectStyler.trigger` or `SegmentedControlStyler.item` icon size explicitly to
retain a custom size; per-item SegmentedControl styles remain supported.
