### PR TITLE
feat(tooltip): expose controlled visibility and preserve dismissal

### DIFF
--- a/apps/playground/lib/ui/components/tooltip.g.dart
+++ b/apps/playground/lib/ui/components/tooltip.g.dart
@@ -25,6 +25,8 @@ class PlaygroundTooltip extends StatelessWidget {
     this.style = const TooltipStyler.create(),
     required this.tooltipChild,
     required this.child,
+    this.open,
+    this.onOpenChanged,
     this.tooltipSemantics,
     this.positioning = const OverlayPositionConfig(),
   });
@@ -34,6 +36,10 @@ class PlaygroundTooltip extends StatelessWidget {
   final Widget tooltipChild;
 
   final Widget child;
+
+  final bool? open;
+
+  final ValueChanged<bool>? onOpenChanged;
 
   final String? tooltipSemantics;
 
@@ -46,6 +52,8 @@ class PlaygroundTooltip extends StatelessWidget {
       style: playgroundTooltipStyle(style: this.style),
       tooltipChild: this.tooltipChild,
       child: this.child,
+      open: this.open,
+      onOpenChanged: this.onOpenChanged,
       tooltipSemantics: this.tooltipSemantics,
       positioning: this.positioning,
     );

--- a/docs/components/tooltip.mdx
+++ b/docs/components/tooltip.mdx
@@ -90,6 +90,18 @@ class _TriggerButton extends StatelessWidget {
 ```
 </CodeGroup>
 
+## Controlled visibility
+
+`RemixTooltip` and `FortalTooltip` accept `open` and `onOpenChanged`.
+Leave `open` null for automatic hover, keyboard-focus, and touch behavior.
+When `open` is a boolean, interaction requests a change through
+`onOpenChanged`; the owner must update `open` to accept it. Changing visibility
+keeps the trigger mounted and preserves its focus.
+
+A controlled, closed tooltip delegates unmodified Escape to an enabled enclosing
+`DismissIntent` action, allowing a containing drawer or menu to dismiss.
+An open tooltip handles Escape by requesting closure.
+
 ## Fortal widgets
 
 The application-owned Fortal preset provides a themed widget for this component:
@@ -136,6 +148,8 @@ RemixTooltip remixTooltipConstructor({
   Key? key,
   required Widget tooltipChild,
   required Widget child,
+  bool? open,
+  ValueChanged<bool>? onOpenChanged,
   String? tooltipSemantics,
   OverlayPositionConfig positioning = const OverlayPositionConfig(),
   TooltipStyler style = const TooltipStyler.create(),
@@ -167,6 +181,14 @@ Optional. The style spec for the tooltip.
 #### `child` → `Widget`
 
 **Required**. The child widget that will trigger the tooltip.
+
+#### `open` → `bool?`
+
+Optional. Controlled visibility, or null for hover/focus/touch-managed visibility.
+
+#### `onOpenChanged` → `ValueChanged<bool>?`
+
+Optional. Requests a visibility change; controlled callers must accept it in `open`.
 
 #### `tooltipSemantics` → `String?`
 
@@ -251,6 +273,6 @@ Applies a matrix transformation to the component.
 
 Sets the widget modifier.
 
-#### `call({Key? key, required Widget tooltipChild, required Widget child, String? tooltipSemantics, OverlayPositionConfig positioning = const OverlayPositionConfig()})`
+#### `call({Key? key, required Widget tooltipChild, required Widget child, bool? open, ValueChanged<bool>? onOpenChanged, String? tooltipSemantics, OverlayPositionConfig positioning = const OverlayPositionConfig()})`
 
 Creates a `RemixTooltip` widget with this style applied.

--- a/packages/remix/CHANGELOG.md
+++ b/packages/remix/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add controlled tooltip visibility and preserve enclosing dismissal actions when closed.
+
 ## 1.0.0-beta.9
 
 - Export the Naked UI constructor and state types required by generated

--- a/packages/remix/lib/src/components/tooltip/tooltip.dart
+++ b/packages/remix/lib/src/components/tooltip/tooltip.dart
@@ -2,6 +2,7 @@ library remix_tooltip;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter/services.dart';
 import 'package:mix/mix.dart';
 import 'package:mix_annotations/mix_annotations.dart';
 import 'package:naked_ui/naked_ui.dart';

--- a/packages/remix/lib/src/components/tooltip/tooltip.g.dart
+++ b/packages/remix/lib/src/components/tooltip/tooltip.g.dart
@@ -698,6 +698,8 @@ class TooltipStyler extends MixStyler<TooltipStyler, TooltipSpec>
     Key? key,
     required Widget tooltipChild,
     required Widget child,
+    bool? open,
+    ValueChanged<bool>? onOpenChanged,
     String? tooltipSemantics,
     OverlayPositionConfig positioning = const OverlayPositionConfig(),
   }) {
@@ -706,6 +708,8 @@ class TooltipStyler extends MixStyler<TooltipStyler, TooltipSpec>
       style: this,
       tooltipChild: tooltipChild,
       child: child,
+      open: open,
+      onOpenChanged: onOpenChanged,
       tooltipSemantics: tooltipSemantics,
       positioning: positioning,
     );

--- a/packages/remix/lib/src/components/tooltip/tooltip_widget.dart
+++ b/packages/remix/lib/src/components/tooltip/tooltip_widget.dart
@@ -9,6 +9,8 @@ class RemixTooltip extends StatelessWidget {
     super.key,
     required this.tooltipChild,
     required this.child,
+    this.open,
+    this.onOpenChanged,
     this.tooltipSemantics,
     this.positioning = const OverlayPositionConfig(),
     this.style = const TooltipStyler.create(),
@@ -27,6 +29,12 @@ class RemixTooltip extends StatelessWidget {
   /// The child widget that will trigger the tooltip.
   final Widget child;
 
+  /// Controlled visibility, or null for hover/focus/touch-managed visibility.
+  final bool? open;
+
+  /// Requests a visibility change; controlled callers must accept it in [open].
+  final ValueChanged<bool>? onOpenChanged;
+
   /// The semantic label for the tooltip.
   final String? tooltipSemantics;
 
@@ -42,6 +50,8 @@ class RemixTooltip extends StatelessWidget {
       styleSpec: styleSpec,
       builder: (context, spec) {
         return NakedTooltip(
+          open: open,
+          onOpenChanged: onOpenChanged,
           overlayBuilder: (context, info) => Box(
             styleSpec: spec.container,
             child: StyleSpecBuilder(
@@ -60,7 +70,30 @@ class RemixTooltip extends StatelessWidget {
               spec.dismissDuration ?? const Duration(milliseconds: 100),
           positioning: positioning,
           semanticLabel: tooltipSemantics,
-          child: child,
+          child: Focus(
+            canRequestFocus: false,
+            skipTraversal: true,
+            includeSemantics: false,
+            onKeyEvent: (_, event) {
+              // A controlled, closed tooltip must not swallow a containing
+              // drawer/menu's dismissal shortcut in NakedTooltip's handler.
+              // Match NakedTooltip's binding so modified Escape is untouched.
+              if (open == false &&
+                  event is KeyDownEvent &&
+                  const SingleActivator(
+                    LogicalKeyboardKey.escape,
+                  ).accepts(event, HardwareKeyboard.instance)) {
+                const intent = DismissIntent();
+                final action = Actions.maybeFind<DismissIntent>(context);
+                if (action != null && action.isEnabled(intent)) {
+                  Actions.invoke(context, intent);
+                  return KeyEventResult.handled;
+                }
+              }
+              return KeyEventResult.ignored;
+            },
+            child: child,
+          ),
         );
       },
     );

--- a/packages/remix/test/components/tooltip/tooltip_controlled_test.dart
+++ b/packages/remix/test/components/tooltip/tooltip_controlled_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remix/remix.dart';
+
+void main() {
+  testWidgets(
+    'controlled visibility requests need acceptance and preserve trigger focus',
+    (tester) async {
+      final focus = FocusNode();
+      final open = ValueNotifier(false);
+      final requests = <bool>[];
+      var dismissed = 0;
+      addTearDown(focus.dispose);
+      addTearDown(open.dispose);
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ValueListenableBuilder<bool>(
+            valueListenable: open,
+            builder: (context, value, _) => Actions(
+              actions: {
+                DismissIntent: CallbackAction<DismissIntent>(
+                  onInvoke: (_) {
+                    dismissed++;
+                    return null;
+                  },
+                ),
+              },
+              child: RemixTooltip(
+                open: value,
+                onOpenChanged: requests.add,
+                tooltipChild: const Text('Tooltip content'),
+                child: RemixButton(
+                  focusNode: focus,
+                  label: 'Trigger',
+                  onPressed: () {},
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      focus.requestFocus();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 301));
+      expect(requests, [true]);
+      expect(find.text('Tooltip content'), findsNothing);
+      open.value = true;
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(find.text('Tooltip content'), findsOneWidget);
+      expect(focus.hasFocus, isTrue);
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      expect(requests, [true, false]);
+      expect(dismissed, 0);
+      open.value = false;
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 200));
+      expect(find.text('Tooltip content'), findsNothing);
+      expect(focus.hasFocus, isTrue);
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      expect(dismissed, 1);
+      expect(focus.hasFocus, isTrue);
+    },
+  );
+
+  testWidgets(
+    'closed controlled tooltip delegates Escape to the enclosing dismiss action',
+    (tester) async {
+      final focus = FocusNode();
+      addTearDown(focus.dispose);
+      var dismissed = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Actions(
+            actions: {
+              DismissIntent: CallbackAction<DismissIntent>(
+                onInvoke: (_) {
+                  dismissed++;
+                  return null;
+                },
+              ),
+            },
+            child: RemixTooltip(
+              open: false,
+              tooltipChild: const Text('Tooltip content'),
+              child: RemixButton(
+                focusNode: focus,
+                label: 'Trigger',
+                onPressed: () {},
+              ),
+            ),
+          ),
+        ),
+      );
+      focus.requestFocus();
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      expect(dismissed, 1);
+    },
+  );
+  testWidgets('closed tooltip delegates only unmodified Escape', (
+    tester,
+  ) async {
+    final focus = FocusNode();
+    addTearDown(focus.dispose);
+    var dismissed = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Actions(
+          actions: {
+            DismissIntent: CallbackAction<DismissIntent>(
+              onInvoke: (_) {
+                dismissed++;
+                return null;
+              },
+            ),
+          },
+          child: RemixTooltip(
+            open: false,
+            tooltipChild: const Text('Tooltip content'),
+            child: RemixButton(
+              focusNode: focus,
+              label: 'Trigger',
+              onPressed: () {},
+            ),
+          ),
+        ),
+      ),
+    );
+    focus.requestFocus();
+    await tester.pump();
+    for (final modifier in [
+      LogicalKeyboardKey.controlLeft,
+      LogicalKeyboardKey.altLeft,
+      LogicalKeyboardKey.shiftLeft,
+      LogicalKeyboardKey.metaLeft,
+    ]) {
+      await tester.sendKeyDownEvent(modifier);
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.sendKeyUpEvent(modifier);
+      expect(dismissed, 0, reason: modifier.debugName);
+    }
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    expect(dismissed, 1);
+  });
+}

--- a/packages/remix_fortal/CHANGELOG.md
+++ b/packages/remix_fortal/CHANGELOG.md
@@ -1,7 +1,3 @@
-## Unreleased
-
-- Expose controlled visibility on FortalTooltip.
-
 ## 1.0.0-beta.9
 
  - **FIX**(data_list): bound minimum intrinsic width by maximum (#185).

--- a/packages/remix_fortal/CHANGELOG.md
+++ b/packages/remix_fortal/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Expose controlled visibility on FortalTooltip.
+
 ## 1.0.0-beta.9
 
  - **FIX**(data_list): bound minimum intrinsic width by maximum (#185).

--- a/packages/remix_fortal/lib/src/components/tooltip.g.dart
+++ b/packages/remix_fortal/lib/src/components/tooltip.g.dart
@@ -13,6 +13,8 @@ class FortalTooltip extends StatelessWidget {
     this.style = const TooltipStyler.create(),
     required this.tooltipChild,
     required this.child,
+    this.open,
+    this.onOpenChanged,
     this.tooltipSemantics,
     this.positioning = const OverlayPositionConfig(),
   });
@@ -22,6 +24,10 @@ class FortalTooltip extends StatelessWidget {
   final Widget tooltipChild;
 
   final Widget child;
+
+  final bool? open;
+
+  final ValueChanged<bool>? onOpenChanged;
 
   final String? tooltipSemantics;
 
@@ -34,6 +40,8 @@ class FortalTooltip extends StatelessWidget {
       style: fortalTooltipStyle(style: this.style),
       tooltipChild: this.tooltipChild,
       child: this.child,
+      open: this.open,
+      onOpenChanged: this.onOpenChanged,
       tooltipSemantics: this.tooltipSemantics,
       positioning: this.positioning,
     );


### PR DESCRIPTION
## Description

`RemixTooltip` and the generated `FortalTooltip` now accept `open` and `onOpenChanged`, forwarding Naked UI's existing controlled-visibility contract. When `open` is null nothing changes: hover, keyboard focus, and long press manage visibility as before. When `open` is a boolean, interaction requests a change through `onOpenChanged`, and the owner accepts it by updating `open`. The trigger stays mounted across visibility changes, so it keeps focus.

A controlled tooltip that is closed now passes an unmodified Escape to an enabled enclosing `DismissIntent`. Without this, NakedTooltip's Escape binding (which is active even when closed) swallows the key, and a containing drawer or menu can't dismiss. The fallback uses the same `SingleActivator(LogicalKeyboardKey.escape)` as NakedTooltip, so Ctrl/Alt/Shift/Meta+Escape are left alone. An open tooltip still handles Escape itself by requesting closure.

This is the first PR in a stack. The upcoming sidebar icon-rail collapse uses controlled tooltips to suppress and dismiss destination labels during motion without swapping out the focused destination.

The three `tooltip.g.dart` changes (Remix, Fortal, and the playground's application-owned `PlaygroundTooltip`) are regenerated constructor forwarding, not hand edits.

Validation, run on this commit alone:
- `flutter test test/components/sidebar test/components/tooltip` (remix): 111 passed
- `flutter test test/components/sidebar test/fortal` (remix_fortal): 96 passed
- `flutter test` (apps/dashboard, which this PR doesn't change): 85 passed
- `flutter analyze`: no issues
- Melos checks, all passed:
  - `generate:check`: every committed generated file reproduced byte-for-byte
  - `open-code:fortal:check`, `docs:check`, `open-code:dogfood:check`
  - `test:cli`: 86 passed
  - `open-code:check`: default and Fortal presets installed against the checkout
- Material-independence and Fortal parity checks: passed
- Regression test: before the fix, `closed tooltip delegates only unmodified Escape` failed on Ctrl+Escape (dismissed 1, expected 0). It passes now.

## Related Issues

None.

---

## Checklist

**Note**: Updating the `pubspec.yaml` and `CHANGELOG.md` is not required. These are handled automatically during the release process.

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
