### PR TITLE
feat(dashboard): integrate collapsible navigation

### DIFF
--- a/apps/dashboard/lib/shell/dashboard_shell.dart
+++ b/apps/dashboard/lib/shell/dashboard_shell.dart
@@ -72,18 +72,14 @@ class _DashboardShellState extends State<DashboardShell> {
               selected: _selected,
               onSelected: _select,
               collapsed: _sidebarCollapsed,
+              onToggle: () =>
+                  setState(() => _sidebarCollapsed = !_sidebarCollapsed),
             ),
           Expanded(
             child: ColumnBox(
               children: [
                 TopBar(
                   page: _selected,
-                  sidebarCollapsed: _sidebarCollapsed,
-                  onSidebarToggle: compact
-                      ? null
-                      : () => setState(
-                          () => _sidebarCollapsed = !_sidebarCollapsed,
-                        ),
                   onMenuPressed: compact
                       ? () => _scaffoldKey.currentState?.openDrawer()
                       : null,

--- a/apps/dashboard/lib/shell/dashboard_shell.dart
+++ b/apps/dashboard/lib/shell/dashboard_shell.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:remix/remix.dart';
 
 import '../pages/charts_page.dart';
 import '../pages/customers_page.dart';
@@ -27,6 +28,7 @@ class _DashboardShellState extends State<DashboardShell> {
   final _scaffoldKey = GlobalKey<ScaffoldState>();
   DashboardPage _selected = .overview;
   String _searchQuery = '';
+  bool _sidebarCollapsed = false;
 
   void _select(DashboardPage page) {
     setState(() => _selected = page);
@@ -62,14 +64,26 @@ class _DashboardShellState extends State<DashboardShell> {
               child: Sidebar(selected: _selected, onSelected: _select),
             )
           : null,
-      body: Row(
+      body: RowBox(
         children: [
-          if (!compact) Sidebar(selected: _selected, onSelected: _select),
+          if (!compact)
+            Sidebar(
+              key: const ValueKey('desktop-sidebar'),
+              selected: _selected,
+              onSelected: _select,
+              collapsed: _sidebarCollapsed,
+            ),
           Expanded(
-            child: Column(
+            child: ColumnBox(
               children: [
                 TopBar(
                   page: _selected,
+                  sidebarCollapsed: _sidebarCollapsed,
+                  onSidebarToggle: compact
+                      ? null
+                      : () => setState(
+                          () => _sidebarCollapsed = !_sidebarCollapsed,
+                        ),
                   onMenuPressed: compact
                       ? () => _scaffoldKey.currentState?.openDrawer()
                       : null,

--- a/apps/dashboard/lib/shell/dashboard_shell_layout.dart
+++ b/apps/dashboard/lib/shell/dashboard_shell_layout.dart
@@ -4,6 +4,7 @@ import 'package:remix_fortal/remix_fortal.dart';
 
 const dashboardCompactBreakpoint = 720.0;
 const dashboardSidebarWidth = 256.0;
+const dashboardSidebarCollapsedWidth = 72.0;
 const dashboardShellHeaderHeight = 64.0;
 
 class DashboardShellHeader extends StatelessWidget {
@@ -21,7 +22,7 @@ class DashboardShellHeader extends StatelessWidget {
     return Box(
       style: BoxStyler()
           .height(dashboardShellHeaderHeight)
-          .alignment(.centerLeft)
+          .alignment(AlignmentDirectional.centerStart)
           .padding(.horizontal(horizontalPadding))
           .color(FortalTokens.colorPanelSolid())
           .border(

--- a/apps/dashboard/lib/shell/dashboard_shell_layout.dart
+++ b/apps/dashboard/lib/shell/dashboard_shell_layout.dart
@@ -6,6 +6,15 @@ const dashboardCompactBreakpoint = 720.0;
 const dashboardSidebarWidth = 256.0;
 const dashboardSidebarCollapsedWidth = 72.0;
 const dashboardShellHeaderHeight = 64.0;
+const dashboardToolbarButtonSize = 40.0;
+
+/// Square ghost target shared by top bar and sidebar header actions.
+final dashboardToolbarButtonStyle = fortalIconButtonStyle(variant: .ghost)
+    .width(dashboardToolbarButtonSize)
+    .height(dashboardToolbarButtonSize)
+    .padding(.all(0))
+    .margin(.all(0))
+    .container(.alignment(.center));
 
 class DashboardShellHeader extends StatelessWidget {
   const DashboardShellHeader({

--- a/apps/dashboard/lib/shell/sidebar.dart
+++ b/apps/dashboard/lib/shell/sidebar.dart
@@ -16,9 +16,13 @@ class Sidebar extends StatelessWidget {
     required this.selected,
     required this.onSelected,
     this.collapsed = false,
+    this.onToggle,
   });
 
   final bool collapsed;
+
+  /// Collapses or expands the desktop panel; null hides the control (drawer).
+  final VoidCallback? onToggle;
 
   final DashboardPage selected;
   final ValueChanged<DashboardPage> onSelected;
@@ -35,7 +39,7 @@ class Sidebar extends StatelessWidget {
       expandedWidth: dashboardSidebarWidth,
       collapsedWidth: dashboardSidebarCollapsedWidth,
       panelPadding: insets,
-      header: const _Brand(),
+      header: _Brand(collapsed: collapsed, onToggle: onToggle),
       sections: dashboardSidebarSections,
       selectedValue: selected,
       onSelected: onSelected,
@@ -46,34 +50,79 @@ class Sidebar extends StatelessWidget {
 }
 
 class _Brand extends StatelessWidget {
-  const _Brand();
+  const _Brand({required this.collapsed, required this.onToggle});
+
+  final bool collapsed;
+  final VoidCallback? onToggle;
 
   @override
   Widget build(BuildContext context) {
     final motion = RemixSidebar.animationOf(context);
+    final inset = FortalTokens.space3.resolve(context);
+    final label = collapsed ? 'Expand navigation' : 'Collapse navigation';
     return DashboardShellHeader(
       key: const ValueKey('dashboard-brand'),
-      horizontalPadding: FortalTokens.space4(),
-      child: Semantics(
-        label: 'Dashboard',
-        excludeSemantics: true,
-        child: Stack(
-          alignment: AlignmentDirectional.centerStart,
-          children: [
-            Opacity(
-              opacity: 1 - motion.labelOpacity,
-              child: const FortalText('D', size: .size5, weight: .bold),
+      horizontalPadding: FortalTokens.space3(),
+      child: RowBox(
+        children: [
+          Expanded(
+            child: Semantics(
+              label: 'Dashboard',
+              excludeSemantics: true,
+              // The wordmark starts where expanded destination icons start.
+              child: Padding(
+                padding: EdgeInsetsDirectional.only(
+                  start: FortalTokens.space4.resolve(context),
+                ),
+                child: _SidebarTextReveal(
+                  motion: motion,
+                  child: const FortalText(
+                    'Dashboard',
+                    size: .size5,
+                    weight: .bold,
+                  ),
+                ),
+              ),
             ),
-            _SidebarTextReveal(
-              motion: motion,
-              child: const FortalText('Dashboard', size: .size5, weight: .bold),
+          ),
+          if (onToggle case final onToggle?) ...[
+            FortalTooltip(
+              positioning: OverlayPositionConfig(
+                side: Directionality.of(context) == TextDirection.ltr
+                    ? OverlaySide.right
+                    : OverlaySide.left,
+                alignment: OverlayAlignment.center,
+              ),
+              tooltipChild: ExcludeSemantics(child: Text(label)),
+              child: RemixIconButton(
+                key: const ValueKey('dashboard-sidebar-toggle'),
+                semanticLabel: label,
+                style: dashboardToolbarButtonStyle,
+                onPressed: onToggle,
+                icon: collapsed ? Icons.menu : Icons.menu_open,
+              ),
+            ),
+            // The toggle rides the trailing edge and settles on the rail's
+            // center line with the destination icons.
+            SizedBox(
+              width:
+                  (_railCenter(context) -
+                          inset -
+                          dashboardToolbarButtonSize / 2)
+                      .clamp(0.0, double.infinity),
             ),
           ],
-        ),
+        ],
       ),
     );
   }
 }
+
+/// Center line of the collapsed rail, where destination icons settle.
+double _railCenter(BuildContext context) =>
+    (dashboardSidebarCollapsedWidth -
+        FortalTokens.borderWidth1.resolve(context)) /
+    2;
 
 class _Profile extends StatelessWidget {
   const _Profile();
@@ -81,60 +130,63 @@ class _Profile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final motion = RemixSidebar.animationOf(context);
+    final inset = FortalTokens.space2.resolve(context);
+    // The avatar stays on the rail's center line in both presentations.
+    final lead =
+        (_railCenter(context) -
+                inset -
+                FortalTokens.space6.resolve(context) / 2)
+            .clamp(0.0, double.infinity);
     return Box(
-      style: BoxStyler().padding(.all(8 + 6 * motion.expansion)),
+      style: BoxStyler().padding(
+        .symmetric(
+          horizontal: FortalTokens.space2(),
+          vertical: FortalTokens.space3(),
+        ),
+      ),
       child: DashboardActionMenu(
         key: const ValueKey('sidebar-account-trigger'),
         semanticLabel: 'Workspace account menu',
         trigger: ConstrainedBox(
           constraints: const BoxConstraints(minHeight: 48),
-          child: LayoutBuilder(
-            builder: (context, constraints) => RowBox(
-              children: [
-                SizedBox(
-                  width:
-                      ((constraints.maxWidth -
-                                  FortalTokens.space6.resolve(context)) /
-                              2)
-                          .clamp(0.0, double.infinity) *
-                      (1 - motion.expansion),
-                ),
-                const FortalAvatar(label: 'LF', size: .size2),
-                SizedBox(width: 10 * motion.expansion),
-                Expanded(
-                  child: _SidebarTextReveal(
-                    motion: motion,
-                    child: ColumnBox(
-                      style: FlexBoxStyler()
-                          .mainAxisSize(.min)
-                          .crossAxisAlignment(.start),
-                      children: [
-                        const FortalText(
-                          'Leo Farias',
-                          size: .size2,
-                          weight: .medium,
-                        ),
-                        StyledText(
-                          'leo@remix.dev',
-                          style: dashboardText(
-                            .size1,
-                            tone: .muted,
-                          ).maxLines(1).softWrap(false),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-                _SidebarTextReveal(
+          child: RowBox(
+            children: [
+              SizedBox(width: lead),
+              const FortalAvatar(label: 'LF', size: .size2),
+              SizedBox(width: 10 * motion.expansion),
+              Expanded(
+                child: _SidebarTextReveal(
                   motion: motion,
-                  child: Icon(
-                    Icons.more_horiz,
-                    size: 18,
-                    color: MixScope.tokenOf(FortalTokens.gray11, context),
+                  child: ColumnBox(
+                    style: FlexBoxStyler()
+                        .mainAxisSize(.min)
+                        .crossAxisAlignment(.start),
+                    children: [
+                      const FortalText(
+                        'Leo Farias',
+                        size: .size2,
+                        weight: .medium,
+                      ),
+                      StyledText(
+                        'leo@remix.dev',
+                        style: dashboardText(
+                          .size1,
+                          tone: .muted,
+                        ).maxLines(1).softWrap(false),
+                      ),
+                    ],
                   ),
                 ),
-              ],
-            ),
+              ),
+              _SidebarTextReveal(
+                motion: motion,
+                child: Icon(
+                  Icons.more_horiz,
+                  size: 18,
+                  color: MixScope.tokenOf(FortalTokens.gray11, context),
+                ),
+              ),
+            ],
           ),
         ),
         actions: const [

--- a/apps/dashboard/lib/shell/sidebar.dart
+++ b/apps/dashboard/lib/shell/sidebar.dart
@@ -11,7 +11,14 @@ import 'dashboard_shell_layout.dart';
 import 'sidebar_sections.dart';
 
 class Sidebar extends StatelessWidget {
-  const Sidebar({super.key, required this.selected, required this.onSelected});
+  const Sidebar({
+    super.key,
+    required this.selected,
+    required this.onSelected,
+    this.collapsed = false,
+  });
+
+  final bool collapsed;
 
   final DashboardPage selected;
   final ValueChanged<DashboardPage> onSelected;
@@ -23,17 +30,17 @@ class Sidebar extends StatelessWidget {
     // surface instead of putting a SafeArea around that surface.
     final insets = MediaQuery.paddingOf(context);
 
-    return SizedBox(
-      width: dashboardSidebarWidth,
-      child: FortalSidebar<DashboardPage>(
-        panelPadding: insets,
-        header: const _Brand(),
-        sections: dashboardSidebarSections,
-        selectedValue: selected,
-        onSelected: onSelected,
-        footer: const _Profile(),
-        semanticLabel: 'Dashboard navigation',
-      ),
+    return FortalSidebar<DashboardPage>(
+      collapsed: collapsed,
+      expandedWidth: dashboardSidebarWidth,
+      collapsedWidth: dashboardSidebarCollapsedWidth,
+      panelPadding: insets,
+      header: const _Brand(),
+      sections: dashboardSidebarSections,
+      selectedValue: selected,
+      onSelected: onSelected,
+      footer: const _Profile(),
+      semanticLabel: 'Dashboard navigation',
     );
   }
 }
@@ -43,10 +50,27 @@ class _Brand extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final motion = RemixSidebar.animationOf(context);
     return DashboardShellHeader(
       key: const ValueKey('dashboard-brand'),
       horizontalPadding: FortalTokens.space4(),
-      child: const FortalText('Dashboard', size: .size5, weight: .bold),
+      child: Semantics(
+        label: 'Dashboard',
+        excludeSemantics: true,
+        child: Stack(
+          alignment: AlignmentDirectional.centerStart,
+          children: [
+            Opacity(
+              opacity: 1 - motion.labelOpacity,
+              child: const FortalText('D', size: .size5, weight: .bold),
+            ),
+            _SidebarTextReveal(
+              motion: motion,
+              child: const FortalText('Dashboard', size: .size5, weight: .bold),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }
@@ -56,33 +80,62 @@ class _Profile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.all(14),
+    final motion = RemixSidebar.animationOf(context);
+    return Box(
+      style: BoxStyler().padding(.all(8 + 6 * motion.expansion)),
       child: DashboardActionMenu(
         key: const ValueKey('sidebar-account-trigger'),
         semanticLabel: 'Workspace account menu',
-        trigger: Row(
-          spacing: 10,
-          children: [
-            const FortalAvatar(label: 'LF', size: .size2),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: .start,
-                children: [
-                  const FortalText('Leo Farias', size: .size2, weight: .medium),
-                  StyledText(
-                    'leo@remix.dev',
-                    style: dashboardText(.size1, tone: .muted),
+        trigger: ConstrainedBox(
+          constraints: const BoxConstraints(minHeight: 48),
+          child: LayoutBuilder(
+            builder: (context, constraints) => RowBox(
+              children: [
+                SizedBox(
+                  width:
+                      ((constraints.maxWidth -
+                                  FortalTokens.space6.resolve(context)) /
+                              2)
+                          .clamp(0.0, double.infinity) *
+                      (1 - motion.expansion),
+                ),
+                const FortalAvatar(label: 'LF', size: .size2),
+                SizedBox(width: 10 * motion.expansion),
+                Expanded(
+                  child: _SidebarTextReveal(
+                    motion: motion,
+                    child: ColumnBox(
+                      style: FlexBoxStyler()
+                          .mainAxisSize(.min)
+                          .crossAxisAlignment(.start),
+                      children: [
+                        const FortalText(
+                          'Leo Farias',
+                          size: .size2,
+                          weight: .medium,
+                        ),
+                        StyledText(
+                          'leo@remix.dev',
+                          style: dashboardText(
+                            .size1,
+                            tone: .muted,
+                          ).maxLines(1).softWrap(false),
+                        ),
+                      ],
+                    ),
                   ),
-                ],
-              ),
+                ),
+                _SidebarTextReveal(
+                  motion: motion,
+                  child: Icon(
+                    Icons.more_horiz,
+                    size: 18,
+                    color: MixScope.tokenOf(FortalTokens.gray11, context),
+                  ),
+                ),
+              ],
             ),
-            Icon(
-              Icons.more_horiz,
-              size: 18,
-              color: MixScope.tokenOf(FortalTokens.gray11, context),
-            ),
-          ],
+          ),
         ),
         actions: const [
           DashboardAction(value: 'profile', label: 'View profile'),
@@ -102,4 +155,23 @@ class _Profile extends StatelessWidget {
       ),
     );
   }
+}
+
+/// Clips only non-interactive text; the surrounding menu and focus ring remain.
+class _SidebarTextReveal extends StatelessWidget {
+  const _SidebarTextReveal({required this.motion, required this.child});
+  final SidebarAnimation motion;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) => ClipRect(
+    child: Align(
+      alignment: AlignmentDirectional.centerStart,
+      widthFactor: motion.expansion,
+      child: Opacity(
+        opacity: motion.labelOpacity,
+        child: Offstage(offstage: motion.expansion == 0, child: child),
+      ),
+    ),
+  );
 }

--- a/apps/dashboard/lib/shell/top_bar.dart
+++ b/apps/dashboard/lib/shell/top_bar.dart
@@ -17,11 +17,15 @@ class TopBar extends StatefulWidget {
     required this.page,
     required this.onSearchChanged,
     this.onMenuPressed,
+    this.onSidebarToggle,
+    this.sidebarCollapsed = false,
   });
 
   final DashboardPage page;
   final ValueChanged<String> onSearchChanged;
   final VoidCallback? onMenuPressed;
+  final VoidCallback? onSidebarToggle;
+  final bool sidebarCollapsed;
 
   @override
   State<TopBar> createState() => _TopBarState();
@@ -35,43 +39,71 @@ class _TopBarState extends State<TopBar> {
   Widget build(BuildContext context) {
     final width = MediaQuery.sizeOf(context).width;
     final compact = width < dashboardCompactBreakpoint;
+    final toolbarButtonStyle = fortalIconButtonStyle(variant: .ghost)
+        .width(40)
+        .height(40)
+        .padding(.all(0))
+        .margin(.all(0))
+        .container(.alignment(.center));
+    final navigationLabel = widget.sidebarCollapsed
+        ? 'Expand navigation'
+        : 'Collapse navigation';
     return DashboardShellHeader(
       horizontalPadding: compact
           ? FortalTokens.space3()
           : FortalTokens.space5(),
-      child: Row(
-        spacing: 12,
+      child: RowBox(
+        style: FlexBoxStyler().spacing(FortalTokens.space2()),
         children: [
           if (widget.onMenuPressed case final onMenuPressed?)
-            FortalIconButton.ghost(
+            RemixIconButton(
               key: const ValueKey('dashboard-menu'),
               semanticLabel: 'Open navigation',
+              style: toolbarButtonStyle,
               onPressed: onMenuPressed,
               icon: Icons.menu,
             ),
-          if (width > 900) ...[
-            StyledText(
-              widget.page.section.label,
-              style: dashboardText(.size2, tone: .muted),
+          if (widget.onSidebarToggle case final onToggle?)
+            FortalTooltip(
+              tooltipChild: ExcludeSemantics(child: Text(navigationLabel)),
+              child: RemixIconButton(
+                key: const ValueKey('dashboard-sidebar-toggle'),
+                semanticLabel: navigationLabel,
+                style: toolbarButtonStyle,
+                onPressed: onToggle,
+                icon: widget.sidebarCollapsed ? Icons.menu : Icons.menu_open,
+              ),
             ),
-            Icon(
-              Icons.chevron_right,
-              size: 14,
-              color: MixScope.tokenOf(FortalTokens.gray8, context),
-            ),
-          ],
-          Flexible(
-            // The breadcrumb repeats the page title the page header already
-            // publishes as a heading, so it stays plain truncating text.
-            child: StyledText(
-              widget.page.label,
-              style: dashboardTextLine(.size4, weight: .bold),
+          Expanded(
+            child: RowBox(
+              style: FlexBoxStyler().spacing(FortalTokens.space3()),
+              children: [
+                if (width > 900) ...[
+                  StyledText(
+                    widget.page.section.label,
+                    style: dashboardText(.size2, tone: .muted),
+                  ),
+                  StyledIcon(
+                    icon: Directionality.of(context) == TextDirection.ltr
+                        ? Icons.chevron_right
+                        : Icons.chevron_left,
+                    style: IconStyler().size(14).color(FortalTokens.gray8()),
+                  ),
+                ],
+                Flexible(
+                  // Context repeats the page heading; it is not another heading
+                  // or a workspace-switching control.
+                  child: StyledText(
+                    widget.page.label,
+                    style: dashboardTextLine(.size4, weight: .bold),
+                  ),
+                ),
+              ],
             ),
           ),
-          const Spacer(),
           if (width > 1000)
-            SizedBox(
-              width: 260,
+            Box(
+              style: BoxStyler().width(260),
               child: FortalTextField(
                 key: const ValueKey('global-search'),
                 leading: const Icon(Icons.search, size: 18),
@@ -79,9 +111,10 @@ class _TopBarState extends State<TopBar> {
                 onChanged: widget.onSearchChanged,
               ),
             ),
-          FortalIconButton.ghost(
+          RemixIconButton(
             key: const ValueKey('theme-quick-toggle'),
             semanticLabel: 'Toggle dark mode',
+            style: toolbarButtonStyle,
             onPressed: () {
               final theme = ThemeScope.of(context);
               final isDark = FortalTheme.of(context).isDark;
@@ -102,14 +135,16 @@ class _TopBarState extends State<TopBar> {
               alignment: .end,
               sideOffset: 8,
             ),
-            popoverChild: SizedBox(
-              width: 330,
-              child: Column(
-                mainAxisSize: .min,
-                crossAxisAlignment: .stretch,
-                spacing: 10,
+            popoverChild: Box(
+              key: const ValueKey('topbar-notifications-content'),
+              style: BoxStyler().width(330),
+              child: ColumnBox(
+                style: FlexBoxStyler()
+                    .mainAxisSize(.min)
+                    .crossAxisAlignment(.stretch)
+                    .spacing(10),
                 children: [
-                  Row(
+                  RowBox(
                     children: [
                       const Expanded(
                         child: FortalHeading(
@@ -133,26 +168,24 @@ class _TopBarState extends State<TopBar> {
                     ],
                   ),
                   for (final event in activityEvents.take(4))
-                    Row(
-                      crossAxisAlignment: .start,
-                      spacing: 9,
+                    RowBox(
+                      style: FlexBoxStyler()
+                          .crossAxisAlignment(.start)
+                          .spacing(9),
                       children: [
-                        Container(
-                          width: 7,
-                          height: 7,
-                          margin: const EdgeInsets.only(top: 6),
-                          decoration: BoxDecoration(
-                            color: MixScope.tokenOf(
-                              FortalTokens.accent9,
-                              context,
-                            ),
-                            shape: .circle,
-                          ),
+                        Box(
+                          style: BoxStyler()
+                              .width(7)
+                              .height(7)
+                              .margin(.top(6))
+                              .color(FortalTokens.accent9())
+                              .borderRadius(.circular(4)),
                         ),
                         Expanded(
-                          child: Column(
-                            crossAxisAlignment: .start,
-                            spacing: 2,
+                          child: ColumnBox(
+                            style: FlexBoxStyler()
+                                .crossAxisAlignment(.start)
+                                .spacing(2),
                             children: [
                               FortalText(
                                 event.title,
@@ -171,8 +204,9 @@ class _TopBarState extends State<TopBar> {
                 ],
               ),
             ),
-            child: FortalIconButton.ghost(
+            child: RemixIconButton(
               semanticLabel: 'Notifications',
+              style: toolbarButtonStyle,
               onPressed: _toggleNotifications,
               icon: Icons.notifications_none,
               iconBuilder: (context, spec, icon) => Stack(
@@ -185,13 +219,12 @@ class _TopBarState extends State<TopBar> {
                   Positioned(
                     right: -1,
                     top: -1,
-                    child: Container(
-                      width: 7,
-                      height: 7,
-                      decoration: BoxDecoration(
-                        color: MixScope.tokenOf(FortalTokens.accent9, context),
-                        shape: .circle,
-                      ),
+                    child: Box(
+                      style: BoxStyler()
+                          .width(7)
+                          .height(7)
+                          .color(FortalTokens.accent9())
+                          .borderRadius(.circular(4)),
                     ),
                   ),
                 ],
@@ -207,16 +240,14 @@ class _TopBarState extends State<TopBar> {
               alignment: .end,
               sideOffset: 8,
             ),
-            popoverChild: SizedBox(
-              width: 400,
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(maxHeight: 650),
-                child: const SingleChildScrollView(child: ThemePanel()),
-              ),
+            popoverChild: Box(
+              style: BoxStyler().width(400).maxHeight(650),
+              child: const SingleChildScrollView(child: ThemePanel()),
             ),
-            child: FortalIconButton.ghost(
+            child: RemixIconButton(
               key: const ValueKey('theme-panel-trigger'),
               semanticLabel: 'Theme settings',
+              style: toolbarButtonStyle,
               onPressed: _toggleTheme,
               icon: Icons.palette_outlined,
             ),

--- a/apps/dashboard/lib/shell/top_bar.dart
+++ b/apps/dashboard/lib/shell/top_bar.dart
@@ -17,15 +17,11 @@ class TopBar extends StatefulWidget {
     required this.page,
     required this.onSearchChanged,
     this.onMenuPressed,
-    this.onSidebarToggle,
-    this.sidebarCollapsed = false,
   });
 
   final DashboardPage page;
   final ValueChanged<String> onSearchChanged;
   final VoidCallback? onMenuPressed;
-  final VoidCallback? onSidebarToggle;
-  final bool sidebarCollapsed;
 
   @override
   State<TopBar> createState() => _TopBarState();
@@ -39,15 +35,7 @@ class _TopBarState extends State<TopBar> {
   Widget build(BuildContext context) {
     final width = MediaQuery.sizeOf(context).width;
     final compact = width < dashboardCompactBreakpoint;
-    final toolbarButtonStyle = fortalIconButtonStyle(variant: .ghost)
-        .width(40)
-        .height(40)
-        .padding(.all(0))
-        .margin(.all(0))
-        .container(.alignment(.center));
-    final navigationLabel = widget.sidebarCollapsed
-        ? 'Expand navigation'
-        : 'Collapse navigation';
+    final toolbarButtonStyle = dashboardToolbarButtonStyle;
     return DashboardShellHeader(
       horizontalPadding: compact
           ? FortalTokens.space3()
@@ -62,17 +50,6 @@ class _TopBarState extends State<TopBar> {
               style: toolbarButtonStyle,
               onPressed: onMenuPressed,
               icon: Icons.menu,
-            ),
-          if (widget.onSidebarToggle case final onToggle?)
-            FortalTooltip(
-              tooltipChild: ExcludeSemantics(child: Text(navigationLabel)),
-              child: RemixIconButton(
-                key: const ValueKey('dashboard-sidebar-toggle'),
-                semanticLabel: navigationLabel,
-                style: toolbarButtonStyle,
-                onPressed: onToggle,
-                icon: widget.sidebarCollapsed ? Icons.menu : Icons.menu_open,
-              ),
             ),
           Expanded(
             child: RowBox(

--- a/apps/dashboard/test/app_smoke_test.dart
+++ b/apps/dashboard/test/app_smoke_test.dart
@@ -904,7 +904,9 @@ void main() {
       of: topBar,
       matching: find.byKey(const ValueKey('remix-icon-button-surface')),
     );
-    expect(surfaces, findsNWidgets(4));
+    // Theme, notifications, and theme panel; the collapse control lives in
+    // the sidebar header.
+    expect(surfaces, findsNWidgets(3));
 
     void expectSquareSurfaces() {
       for (final surface in surfaces.evaluate()) {

--- a/apps/dashboard/test/app_smoke_test.dart
+++ b/apps/dashboard/test/app_smoke_test.dart
@@ -616,13 +616,9 @@ void main() {
     await tester.tap(find.byIcon(Icons.notifications_none));
     await tester.pump();
 
-    final content = find.ancestor(
-      of: find.text('Mark all read'),
-      matching: find.byWidgetPredicate(
-        (widget) => widget is SizedBox && widget.width == 330,
-      ),
-    );
+    final content = find.byKey(const ValueKey('topbar-notifications-content'));
     expect(content, findsOneWidget);
+    expect(tester.getSize(content).width, 330);
     expect(tester.getSize(content).height, lessThan(300));
   });
 
@@ -908,7 +904,7 @@ void main() {
       of: topBar,
       matching: find.byKey(const ValueKey('remix-icon-button-surface')),
     );
-    expect(surfaces, findsNWidgets(3));
+    expect(surfaces, findsNWidgets(4));
 
     void expectSquareSurfaces() {
       for (final surface in surfaces.evaluate()) {

--- a/apps/dashboard/test/sidebar_motion_test.dart
+++ b/apps/dashboard/test/sidebar_motion_test.dart
@@ -3,6 +3,7 @@ import 'dart:ui' as ui;
 
 import 'package:dashboard/main.dart';
 import 'package:dashboard/shell/sidebar.dart';
+import 'package:dashboard/shell/sidebar_sections.dart';
 import 'package:dashboard/shell/top_bar.dart';
 import 'package:dashboard/theme/theme_settings.dart';
 import 'package:remix_fortal/remix_fortal.dart';
@@ -94,6 +95,41 @@ void main() {
       );
       expect(tester.takeException(), isNull);
     }
+  });
+
+  testWidgets('icons and the sidebar toggle hold the rail center line', (
+    tester,
+  ) async {
+    await mount(tester);
+    final sidebar = find.byType(Sidebar);
+    final icons = [
+      dashboardSidebarSections.first.destinations.first.icon!,
+      dashboardSidebarSections[1].destinations.first.icon!,
+    ];
+    Offset center(IconData icon) => tester.getCenter(
+      find.descendant(of: sidebar, matching: find.byIcon(icon)).first,
+    );
+    final start = [for (final icon in icons) center(icon)];
+    for (final collapsed in [true, false]) {
+      await tester.tap(toggle);
+      await tester.pump();
+      for (var i = 0; i < 14; i++) {
+        await tester.pump(const Duration(milliseconds: 16));
+        for (var j = 0; j < icons.length; j++) {
+          expect(center(icons[j]).dx, closeTo(start[j].dx, .6));
+          expect(center(icons[j]).dy, closeTo(start[j].dy, .01));
+        }
+      }
+      if (collapsed) {
+        // The toggle lives in the sidebar header and settles on the rail.
+        expect(find.descendant(of: sidebar, matching: toggle), findsOneWidget);
+        expect(
+          tester.getCenter(toggle).dx,
+          closeTo(center(icons.first).dx, .6),
+        );
+      }
+    }
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets(

--- a/apps/dashboard/test/sidebar_motion_test.dart
+++ b/apps/dashboard/test/sidebar_motion_test.dart
@@ -1,0 +1,276 @@
+import 'dart:io';
+import 'dart:ui' as ui;
+
+import 'package:dashboard/main.dart';
+import 'package:dashboard/shell/sidebar.dart';
+import 'package:dashboard/shell/top_bar.dart';
+import 'package:dashboard/theme/theme_settings.dart';
+import 'package:remix_fortal/remix_fortal.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+final _captureKey = GlobalKey();
+
+void main() {
+  Future<void> mount(
+    WidgetTester tester, {
+    Size size = const Size(1280, 900),
+  }) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = size;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(
+      RepaintBoundary(key: _captureKey, child: const DashboardApp()),
+    );
+    await tester.pump(const Duration(seconds: 1));
+  }
+
+  final toggle = find.byKey(const ValueKey('dashboard-sidebar-toggle')).first;
+  double width(WidgetTester tester) =>
+      tester.getSize(find.byType(Sidebar)).width;
+
+  testWidgets(
+    'toolbar actions stay at the trailing edge with usable navigation targets',
+    (tester) async {
+      await mount(tester);
+      for (final collapsed in [false, true]) {
+        if (collapsed) {
+          await tester.tap(toggle);
+          await tester.pump();
+          await tester.pump(const Duration(milliseconds: 216));
+        }
+        final bar = tester.getRect(find.byType(TopBar));
+        final account = tester.getRect(
+          find.byKey(const ValueKey('topbar-account-trigger')),
+        );
+        expect(account.right, closeTo(bar.right - 24, .01));
+        // The bottom divider consumes one pixel of the 64px header.
+        expect(account.center.dy, closeTo(bar.center.dy - .5, .01));
+        expect(tester.getSize(toggle).width, greaterThanOrEqualTo(40));
+        expect(tester.getSize(toggle).height, greaterThanOrEqualTo(40));
+      }
+      tester.view.physicalSize = const Size(390, 844);
+      await tester.pump();
+      final menu = find.byKey(const ValueKey('dashboard-menu')).first;
+      expect(tester.getSize(menu).width, greaterThanOrEqualTo(40));
+      expect(
+        tester
+            .getRect(find.byKey(const ValueKey('topbar-account-trigger')))
+            .right,
+        closeTo(390 - 12, .01),
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets('collapsed account avatar stays centered across theme scales', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(1280, 900);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    for (final scaling in FortalScaling.values) {
+      await tester.pumpWidget(
+        DashboardApp(
+          key: ValueKey(scaling),
+          initialSettings: ThemeSettings(scaling: scaling),
+        ),
+      );
+      await tester.tap(toggle);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 216));
+      final trigger = find.byKey(const ValueKey('sidebar-account-trigger'));
+      final avatar = find.descendant(
+        of: trigger,
+        matching: find.byType(FortalAvatar),
+      );
+      expect(
+        tester.getCenter(avatar).dx,
+        closeTo(tester.getCenter(trigger).dx, .01),
+      );
+      expect(tester.takeException(), isNull);
+    }
+  });
+
+  testWidgets(
+    'desktop animates in both directions with usable targets and stable focus',
+    (tester) async {
+      await mount(tester);
+      expect(width(tester), 256);
+      final iconFocus = Focus.of(
+        tester.element(
+          find.descendant(of: toggle, matching: find.byType(Icon)).first,
+        ),
+      );
+      final buttonFocus = iconFocus.canRequestFocus
+          ? iconFocus
+          : iconFocus.ancestors.firstWhere((node) => node.canRequestFocus);
+      buttonFocus.requestFocus();
+      await tester.pump();
+      await _capture(tester, 'desktop-expanded');
+      for (final collapsed in [true, false]) {
+        await tester.tap(toggle);
+        await tester.pump();
+        await tester.pump();
+        final focused = FocusManager.instance.primaryFocus;
+        var elapsed = 0;
+        var previous = width(tester);
+        for (final time in [16, 50, 100, 150, 199, 200, 216]) {
+          await tester.pump(Duration(milliseconds: time - elapsed));
+          elapsed = time;
+          final current = width(tester);
+          expect(current, inInclusiveRange(72.0, 256.0));
+          expect(
+            current,
+            collapsed
+                ? lessThanOrEqualTo(previous)
+                : greaterThanOrEqualTo(previous),
+          );
+          final panel = tester.getRect(find.byType(Sidebar));
+          expect(
+            tester.getRect(find.byType(TopBar)).left,
+            closeTo(panel.right, .01),
+          );
+          expect(FocusManager.instance.primaryFocus, same(focused));
+          final account = tester.getRect(
+            find.byKey(const ValueKey('sidebar-account-trigger')),
+          );
+          expect(account.width, greaterThanOrEqualTo(48));
+          expect(account.height, greaterThanOrEqualTo(48));
+          expect(tester.takeException(), isNull);
+          if (time == 100) {
+            await _capture(
+              tester,
+              collapsed ? 'collapse-middle' : 'expand-middle',
+            );
+          }
+          previous = current;
+        }
+        expect(width(tester), collapsed ? 72 : 256);
+        if (collapsed) {
+          expect(find.text('leo@remix.dev'), findsNothing);
+          await _capture(tester, 'desktop-collapsed');
+        }
+      }
+      await tester.sendKeyEvent(LogicalKeyboardKey.space);
+      await tester.pump();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 216));
+      expect(width(tester), 72);
+    },
+  );
+
+  testWidgets(
+    'collapsed account actions and page selection remain functional',
+    (tester) async {
+      await mount(tester);
+      await tester.tap(toggle);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 250));
+      await tester.pump(const Duration(milliseconds: 250));
+      await tester.tap(find.byKey(const ValueKey('sidebar-account-trigger')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 250));
+      expect(find.text('View profile'), findsOneWidget);
+      await _capture(tester, 'collapsed-account');
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 250));
+      await tester.tap(
+        find.descendant(
+          of: find.byType(Sidebar),
+          matching: find.byIcon(Icons.people_outline),
+        ),
+      );
+      await tester.pump();
+      expect(tester.widget<TopBar>(find.byType(TopBar)).page.name, 'customers');
+      expect(width(tester), 72);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'breakpoint interruptions use an expanded drawer and restore desktop preference',
+    (tester) async {
+      await mount(tester);
+      await tester.tap(toggle);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+      tester.view.physicalSize = const Size(719, 900);
+      await tester.pump();
+      expect(
+        find.byKey(const ValueKey('dashboard-sidebar-toggle')),
+        findsNothing,
+      );
+      final menu = find.byKey(const ValueKey('dashboard-menu'));
+      await tester.tap(menu.first);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(width(tester), 256);
+      await _capture(tester, 'mobile-drawer');
+      await tester.tap(find.text('Customers').first);
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(
+        tester.state<ScaffoldState>(find.byType(Scaffold)).isDrawerOpen,
+        isFalse,
+      );
+      for (final breakpoint in [720.0, 721.0]) {
+        tester.view.physicalSize = Size(breakpoint, 900);
+        await tester.pump();
+        expect(width(tester), 72);
+        expect(toggle, findsOneWidget);
+        expect(tester.takeException(), isNull);
+      }
+    },
+  );
+
+  testWidgets(
+    'short-viewport collapse preserves scroll position within valid extent',
+    (tester) async {
+      await mount(tester, size: const Size(1100, 500));
+      final scroll = find.descendant(
+        of: find.byType(Sidebar),
+        matching: find.byType(Scrollable),
+      );
+      await tester.drag(scroll, const Offset(0, -230));
+      await tester.pump(const Duration(milliseconds: 200));
+      final position = tester.state<ScrollableState>(scroll).position;
+      final before = position.pixels;
+      expect(before, greaterThan(0));
+      await tester.tap(toggle);
+      await tester.pump();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 216));
+      expect(
+        position.pixels,
+        closeTo(
+          before.clamp(position.minScrollExtent, position.maxScrollExtent),
+          .1,
+        ),
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
+}
+
+Future<void> _capture(WidgetTester tester, String name) async {
+  final path = Platform.environment['SIDEBAR_CAPTURE_DIR'];
+  if (path == null) return;
+  final boundary =
+      _captureKey.currentContext!.findRenderObject()! as RenderRepaintBoundary;
+  await tester.runAsync(() async {
+    final image = await boundary.toImage();
+    try {
+      final bytes = await image.toByteData(format: ui.ImageByteFormat.png);
+      await Directory(path).create(recursive: true);
+      await File('$path/$name.png').writeAsBytes(bytes!.buffer.asUint8List());
+    } finally {
+      image.dispose();
+    }
+  });
+}


### PR DESCRIPTION
## Description

> Stacked on https://github.com/conceptadev/remix/pull/196 (sidebar collapse), which is stacked on https://github.com/conceptadev/remix/pull/195 (controlled tooltips). This PR's base is `feat/sidebar-collapse-component`.

The dashboard now uses the collapsible sidebar.

- On desktop, a toggle in the sidebar header collapses the sidebar from 256px to a 72px icon rail and expands it again. The toggle rides the panel's trailing edge and settles on the rail's center line, in line with the destination icons. It has a tooltip, and its accessible name tracks the state ("Collapse navigation" / "Expand navigation"). The shell only owns the collapsed flag and passes it to the sidebar.
- The compact-width drawer always opens expanded and keeps its own open state. Crossing the breakpoint in either direction brings back the desktop collapse preference.
- The brand header and account footer read the sidebar's shared animation through `RemixSidebar.animationOf`. The wordmark starts where the destination icons start. The account avatar sits on the rail's center line in both states, so it never slides, and its actions keep working in the rail.

Toolbar and header changes that come with the integration:
- Every top-bar icon button (menu, dark-mode toggle, notifications, theme settings) and the sidebar toggle share one ghost style with a 40×40 square target.
- The header is built from Mix `RowBox`/`ColumnBox`/`Box` with token spacing, replacing `Row`/`Column`/`SizedBox`/`Container`.
- The section › page context fills the leading space, so the actions stay pinned to the trailing edge. The chevron flips in RTL, and the header aligns to `centerStart`.
- The notifications popover moves to the same Mix layout at 330px wide. Its content is unchanged.

Test updates: the notifications smoke test finds the panel by key instead of by `SizedBox` type and now also asserts the 330px width. The new `sidebar_motion_test.dart` covers:
- icons and the sidebar toggle holding the rail's center line in both directions
- both animation directions
- target sizes
- focus stability
- account actions while collapsed
- breakpoint interruptions
- scroll position preserved across a short-viewport collapse

**Visual evidence:** _To be attached: screenshots of desktop expanded, desktop collapsed, and the mobile drawer, plus a short recording of collapse and expand._

Validation on the top of the stack, after the motion rework:
- `flutter test`: remix sidebar and tooltip 128, remix_fortal sidebar and `test/fortal` 99, apps/dashboard 92, all passing
- `flutter analyze`: no issues
- Melos checks, all passed:
  - `generate:check`: every committed generated file reproduced byte-for-byte
  - `docs:check`, `open-code:dogfood:check`, `open-code:fortal:check`
  - `test:cli`: 86 passed
- Fortal parity check: passed
- `flutter build web --release` of the current dashboard: compiled
- `open-code:check` and the full `test:flutter` run are left to CI for this revision; the local disk was too full to install fresh consumer projects. Before the rework, the full `melos run ci` passed on this stack.

## Related Issues

None.

---

## Checklist

**Note**: Updating the `pubspec.yaml` and `CHANGELOG.md` is not required. These are handled automatically during the release process.

- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
