### PR TITLE
fix(tooltip): honor inherited text layout defaults

### DIFF
--- a/packages/remix/lib/src/components/tooltip/tooltip_widget.dart
+++ b/packages/remix/lib/src/components/tooltip/tooltip_widget.dart
@@ -48,6 +48,12 @@ class RemixTooltip extends StatelessWidget {
               styleSpec: spec.label,
               builder: (context, labelSpec) => DefaultTextStyle.merge(
                 style: labelSpec.style,
+                textAlign: labelSpec.textAlign,
+                softWrap: labelSpec.softWrap,
+                overflow: labelSpec.overflow,
+                maxLines: labelSpec.maxLines,
+                textWidthBasis: labelSpec.textWidthBasis,
+                textHeightBehavior: labelSpec.textHeightBehavior,
                 child: tooltipChild,
               ),
             ),

--- a/packages/remix/test/components/tooltip/tooltip_text_defaults_test.dart
+++ b/packages/remix/test/components/tooltip/tooltip_text_defaults_test.dart
@@ -1,0 +1,78 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remix/remix.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  for (final explicit in [false, true]) {
+    testWidgets(
+      'tooltip text defaults respect explicit child values: $explicit',
+      (tester) async {
+        await tester.pumpRemixApp(
+          RemixTooltip(
+            style: TooltipStyler()
+                .waitDuration(Duration.zero)
+                .label(
+                  TextStyler()
+                      .fontSize(17)
+                      .textAlign(TextAlign.end)
+                      .maxLines(2)
+                      .softWrap(false)
+                      .overflow(TextOverflow.ellipsis)
+                      .textWidthBasis(TextWidthBasis.longestLine)
+                      .textHeightBehavior(
+                        TextHeightBehaviorMix(applyHeightToFirstAscent: false),
+                      ),
+                ),
+            tooltipChild: Padding(
+              padding: const EdgeInsets.all(4),
+              child: Text(
+                'Audit tooltip',
+                style: explicit ? const TextStyle(fontSize: 21) : null,
+                textAlign: explicit ? TextAlign.center : null,
+                maxLines: explicit ? 3 : null,
+                softWrap: explicit ? true : null,
+                overflow: explicit ? TextOverflow.clip : null,
+                textWidthBasis: explicit ? TextWidthBasis.parent : null,
+                textHeightBehavior: explicit
+                    ? const TextHeightBehavior(applyHeightToFirstAscent: true)
+                    : null,
+              ),
+            ),
+            child: const Text('Trigger'),
+          ),
+        );
+        await tester.pumpAndSettle();
+        final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+        await mouse.addPointer(location: Offset.zero);
+        await mouse.moveTo(tester.getCenter(find.text('Trigger')));
+        await tester.pumpAndSettle();
+        final label = tester.widget<RichText>(
+          find.descendant(
+            of: find.text('Audit tooltip'),
+            matching: find.byType(RichText),
+          ),
+        );
+        expect(label.text.style!.fontSize, explicit ? 21 : 17);
+        expect(label.textAlign, explicit ? TextAlign.center : TextAlign.end);
+        expect(label.maxLines, explicit ? 3 : 2);
+        expect(label.softWrap, explicit);
+        expect(
+          label.overflow,
+          explicit ? TextOverflow.clip : TextOverflow.ellipsis,
+        );
+        expect(
+          label.textWidthBasis,
+          explicit ? TextWidthBasis.parent : TextWidthBasis.longestLine,
+        );
+        expect(label.textHeightBehavior!.applyHeightToFirstAscent, explicit);
+        expect(tester.takeException(), isNull);
+        await mouse.removePointer();
+        await tester.pumpAndSettle();
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Description

Tooltip label styles previously forwarded font styling but silently discarded
text-layout defaults. Forward alignment, wrapping, overflow, line limits,
width basis and height behavior through Flutter's DefaultTextStyle.

Explicit descendant Text values still win, and arbitrary tooltip widgets remain
supported. No new renderer or styling API is introduced.

## Related Issues

No linked issue; discovered during the Remix/Fortal property-forwarding audit.

## Checklist

- [x] My PR includes unit or integration tests for all changed behaviors.
- [x] Existing label-style contract is restored; no new public API documentation required.
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is not a breaking change. Previously ignored explicit layout settings now apply.

## Validation

- `fvm flutter test` in packages/remix: 2,745 tests passed.
- `fvm flutter analyze` in packages/remix: passed.
- `fvm exec dart run melos run generate:check --no-select`: passed without drift.
- Tooltip suite: 73 tests passed. Both new inheritance/explicit-child regressions
  passed again after the before/after capture.
- GitHub CI and showcase workflows passed for head `fd8ce5e5ad7fd249100c4bdd15d6fd8a2f44105d`.

## Visual evidence

Real 800×480 Flutter captures request end alignment, two lines and ellipsis.

Before:
![Tooltip ignores text layout defaults](https://github.com/user-attachments/assets/fa4e54de-abf5-40aa-b67d-9254a416b2fc)

After:
![Tooltip honors alignment and two-line ellipsis](https://github.com/user-attachments/assets/fbcbcbc2-f1c1-46d4-b29c-3fa74a1e5a90)
