### PR TITLE
fix(tabs)!: preserve container styling for custom content

### DIFF
--- a/packages/remix/lib/src/components/tabs/tabs_widget.dart
+++ b/packages/remix/lib/src/components/tabs/tabs_widget.dart
@@ -144,7 +144,8 @@ class RemixTab extends StatelessWidget {
          'Either child, builder, or label must be provided',
        );
 
-  /// The tab content when not using [builder].
+  /// Custom content placed inside the styled tab container instead of the
+  /// built-in [label] and [icon]. Use [builder] to replace the container too.
   final Widget? child;
 
   /// The unique identifier for this tab.
@@ -174,7 +175,11 @@ class RemixTab extends StatelessWidget {
   /// Called when press state changes.
   final ValueChanged<bool>? onPressChange;
 
-  /// Custom builder for the tab content.
+  /// Replaces the tab's visual content while retaining its behavior.
+  ///
+  /// The third argument is the styled default container, including [child]
+  /// or the built-in label/icon content. Return it to retain container styling,
+  /// or return another widget to take full control of the visual content.
   final ValueWidgetBuilder<NakedTabState>? builder;
 
   /// Semantic label for accessibility.

--- a/packages/remix/lib/src/components/tabs/tabs_widget.dart
+++ b/packages/remix/lib/src/components/tabs/tabs_widget.dart
@@ -199,15 +199,17 @@ class RemixTab extends StatelessWidget {
     TabSpec spec,
     NakedTabState state,
   ) {
-    final defaultContent =
-        child ??
-        FlexBox(
-          styleSpec: spec.container,
-          children: [
-            if (icon != null) StyledIcon(icon: icon!, styleSpec: spec.icon),
-            if (label != null) StyledText(label!, styleSpec: spec.label),
-          ],
-        );
+    final defaultContent = FlexBox(
+      styleSpec: spec.container,
+      children: [
+        if (child != null)
+          child!
+        else ...[
+          if (icon != null) StyledIcon(icon: icon!, styleSpec: spec.icon),
+          if (label != null) StyledText(label!, styleSpec: spec.label),
+        ],
+      ],
+    );
 
     if (builder != null) {
       return builder!(context, state, defaultContent);

--- a/packages/remix/test/components/tabs/tab_child_container_test.dart
+++ b/packages/remix/test/components/tabs/tab_child_container_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remix/remix.dart';
+
+import '../../helpers/test_helpers.dart';
+
+void main() {
+  for (final customChild in [false, true]) {
+    testWidgets('tab container preserves dimensions with child: $customChild', (
+      tester,
+    ) async {
+      const key = ValueKey('sized-tab');
+      String? selected;
+      await tester.pumpRemixApp(
+        RemixTabs(
+          selectedTabId: 'b',
+          onChanged: (value) => selected = value,
+          child: Column(
+            children: [
+              RemixTabBar(
+                child: Row(
+                  children: [
+                    RemixTab(
+                      key: key,
+                      tabId: 'a',
+                      semanticLabel: 'A',
+                      label: customChild ? null : 'A',
+                      child: customChild
+                          ? const SizedBox(width: 10, height: 10)
+                          : null,
+                      style: TabStyler().container(
+                        FlexBoxStyler().width(80).height(40),
+                      ),
+                    ),
+                    const RemixTab(tabId: 'b', label: 'B'),
+                  ],
+                ),
+              ),
+              const RemixTabView(tabId: 'b', child: Text('Panel')),
+            ],
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(tester.getSize(find.byKey(key)), const Size(80, 40));
+      await tester.tap(find.byKey(key));
+      await tester.pumpAndSettle();
+      expect(selected, 'a');
+      expect(tester.takeException(), isNull);
+    });
+  }
+
+  testWidgets('explicit builder can replace the styled default', (
+    tester,
+  ) async {
+    const key = ValueKey('custom-builder-tab');
+    Widget? defaultContent;
+    await tester.pumpRemixApp(
+      RemixTabs(
+        selectedTabId: 'a',
+        child: RemixTabBar(
+          child: Row(
+            children: [
+              RemixTab(
+                key: key,
+                tabId: 'a',
+                semanticLabel: 'A',
+                child: const SizedBox(width: 10, height: 10),
+                style: TabStyler().container(
+                  FlexBoxStyler().width(80).height(40),
+                ),
+                builder: (_, _, child) {
+                  defaultContent = child;
+                  return const SizedBox(width: 24, height: 24);
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(defaultContent, isA<FlexBox>());
+    expect(tester.getSize(find.byKey(key)), const Size(24, 24));
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
## Description

Custom `RemixTab.child` previously bypassed the resolved container, dropping
its size, padding, decoration and modifiers. Keep custom content inside that
container, matching the standard label/icon path. Selection behavior is unchanged.

An explicit builder still controls the returned widget. Its default-content
argument now includes the styled container instead of the bare custom child.

## Related Issues

No linked issue; found during the Remix/Fortal property-forwarding audit.

## Checklist

- [x] My PR includes unit or integration tests for all changed behaviors.
- [x] Public child/builder documentation explains container styling and replacement.
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

- [x] Yes, this is a breaking change.
- [ ] No, this is not a breaking change.

Callers relying on custom content bypassing container styles must adjust those
styles or return their own widget from `builder`. Builders must not assume the
default argument is the original bare child.

## Validation

- Full Remix suite: 2,746 tests passed.
- Flutter analysis and repository generation check passed.
- Three focused regressions pass after the fix; original code fails the
  custom-child size and styled-builder-default cases.
- GitHub CI and showcase workflows passed for head `3cde80325b13393aa4838f7319e060b1978ad679`.

## Visual evidence

Identical Flutter fixture: both tabs request a 220×64 container with a rounded background.

Before:
![Custom tab content loses container styling](https://github.com/user-attachments/assets/2be077bf-015f-432a-ad4a-dd554ee14939)

After:
![Custom tab content retains container styling](https://github.com/user-attachments/assets/37847384-55c3-4c5f-a8cf-a4c6bd7d4d6b)
