### PR TITLE
fix(menu): preserve root variants in item styles

### DIFF
--- a/packages/remix/lib/src/components/menu/menu_widget.dart
+++ b/packages/remix/lib/src/components/menu/menu_widget.dart
@@ -588,22 +588,50 @@ final class _RemixMenuItemStyles {
       };
     }
 
-    final fluentStyle = styler!;
+    return _MenuItemProjection(
+      styler!,
+      kind,
+      itemStyle,
+    ).build(context).spec.item;
+  }
+}
+
+/// Projects an item only after Mix has merged the menu's active variants.
+final class _MenuItemProjection extends MenuStyler {
+  _MenuItemProjection(this.source, this.kind, this.itemStyle)
+    : super.create(variants: source.$variants);
+
+  final MenuStyler source;
+  final _RemixMenuItemKind kind;
+  final MenuItemStyler itemStyle;
+
+  @override
+  MenuStyler merge(MenuStyler? other) =>
+      _MenuItemProjection(source.merge(other), kind, itemStyle);
+
+  @override
+  StyleSpec<MenuSpec> resolve(BuildContext context) {
     final semanticStyle = switch (kind) {
       .ordinary => null,
-      .checkbox => fluentStyle.$checkboxItem,
-      .radio => fluentStyle.$radioItem,
-      .submenu => fluentStyle.$submenuItem,
+      .checkbox => source.$checkboxItem,
+      .radio => source.$radioItem,
+      .submenu => source.$submenuItem,
     };
-    final menuStyle = MixOps.merge(fluentStyle.$item, semanticStyle);
     final mergedStyle = MixOps.merge(
-      menuStyle,
+      MixOps.merge(source.$item, semanticStyle),
       Prop.maybeMix<StyleSpec<MenuItemSpec>>(itemStyle),
     );
-
-    return MixOps.resolve(context, mergedStyle) ??
-        const StyleSpec(spec: MenuItemSpec());
+    return StyleSpec(
+      spec: MenuSpec(
+        item:
+            MixOps.resolve(context, mergedStyle) ??
+            const StyleSpec(spec: MenuItemSpec()),
+      ),
+    );
   }
+
+  @override
+  List<Object?> get props => [source, kind, itemStyle];
 }
 
 /// One renderer intentionally serves root and recursive submenu overlays so

--- a/packages/remix/test/components/menu/menu_context_variant_test.dart
+++ b/packages/remix/test/components/menu/menu_context_variant_test.dart
@@ -1,0 +1,159 @@
+import 'dart:ui' show PointerDeviceKind;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remix/remix.dart';
+
+void main() {
+  testWidgets(
+    'open menu tracks theme and preserves item hover and kind styles',
+    (tester) async {
+      final brightness = ValueNotifier(Brightness.light);
+      addTearDown(brightness.dispose);
+      final style = MenuStyler()
+          .item(MenuItemStyler().label(TextStyler().fontSize(12)))
+          .onDark(
+            MenuStyler()
+                .item(
+                  MenuItemStyler()
+                      .label(TextStyler().fontSize(24))
+                      .onHovered(
+                        MenuItemStyler().label(TextStyler().fontSize(30)),
+                      ),
+                )
+                .checkboxItem(
+                  MenuItemStyler().label(TextStyler().fontSize(26)),
+                ),
+          );
+      await tester.pumpWidget(
+        MixScope.empty(
+          child: MaterialApp(
+            builder: (context, child) => ValueListenableBuilder(
+              valueListenable: brightness,
+              builder: (context, value, _) => MediaQuery(
+                data: MediaQueryData(platformBrightness: value),
+                child: child!,
+              ),
+            ),
+            home: Scaffold(
+              body: Center(
+                child: RemixMenu<String>(
+                  trigger: const RemixMenuTrigger(label: 'Options'),
+                  onSelected: (_) {},
+                  items: [
+                    const RemixMenuItem(value: 'copy', label: 'Copy'),
+                    RemixMenuCheckboxItem(
+                      value: 'check',
+                      label: 'Checked',
+                      checked: true,
+                      onChanged: (_) {},
+                    ),
+                  ],
+                  style: style,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Options'));
+      await tester.pumpAndSettle();
+      double? fontSize(String label) => tester
+          .widget<RichText>(
+            find.descendant(
+              of: find.text(label),
+              matching: find.byType(RichText),
+            ),
+          )
+          .text
+          .style
+          ?.fontSize;
+      expect(fontSize('Copy'), 12);
+      brightness.value = Brightness.dark;
+      await tester.pumpAndSettle();
+      expect(fontSize('Copy'), 24);
+      expect(fontSize('Checked'), 26);
+      final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await mouse.addPointer(location: Offset.zero);
+      await mouse.moveTo(tester.getCenter(find.text('Copy')));
+      await tester.pumpAndSettle();
+      expect(fontSize('Copy'), 30);
+      await mouse.removePointer();
+      await tester.pumpAndSettle();
+      expect(fontSize('Copy'), 24);
+      brightness.value = Brightness.light;
+      await tester.pumpAndSettle();
+      expect(fontSize('Copy'), 12);
+      expect(fontSize('Checked'), 12);
+    },
+  );
+  for (final brightness in Brightness.values) {
+    for (final overrideSize in <double?>[null, 32]) {
+      testWidgets(
+        'menu root variant $brightness and item override $overrideSize',
+        (tester) async {
+          final style = MenuStyler()
+              .item(MenuItemStyler().label(TextStyler().fontSize(12)))
+              .onDark(
+                MenuStyler().item(
+                  MenuItemStyler().label(TextStyler().fontSize(24)),
+                ),
+              );
+          double? resolvedRootSize;
+          await tester.pumpWidget(
+            MixScope.empty(
+              child: MaterialApp(
+                builder: (context, child) => MediaQuery(
+                  data: MediaQueryData(platformBrightness: brightness),
+                  child: child!,
+                ),
+                home: Scaffold(
+                  body: Center(
+                    child: Column(
+                      children: [
+                        StyleBuilder<MenuSpec>(
+                          style: style,
+                          builder: (context, spec) {
+                            resolvedRootSize =
+                                spec.item.spec.label.spec.style?.fontSize;
+                            return const SizedBox();
+                          },
+                        ),
+                        RemixMenu<String>(
+                          trigger: const RemixMenuTrigger(label: 'Options'),
+                          items: [
+                            RemixMenuItem(
+                              value: 'copy',
+                              label: 'Copy',
+                              style: overrideSize == null
+                                  ? const MenuItemStyler.create()
+                                  : MenuItemStyler().label(
+                                      TextStyler().fontSize(overrideSize),
+                                    ),
+                            ),
+                          ],
+                          style: style,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+          final expectedSize = brightness == Brightness.dark ? 24.0 : 12.0;
+          expect(resolvedRootSize, expectedSize);
+          await tester.tap(find.text('Options'));
+          await tester.pumpAndSettle();
+          final text = tester.widget<RichText>(
+            find.descendant(
+              of: find.text('Copy'),
+              matching: find.byType(RichText),
+            ),
+          );
+          expect(text.text.style?.fontSize, overrideSize ?? expectedSize);
+        },
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Description

Root MenuStyler variants were lost when item properties were extracted before
variant resolution. Resolve them through Mix before composing shared,
item-type and per-item styles. A dark-mode 24px label now renders at 24px
instead of silently retaining its 12px base value.

Raw specs remain authoritative, and selection/controller behavior is unchanged.

## Related Issues

No linked issue; found during the Remix/Fortal property-forwarding audit.

## Checklist

- [x] My PR includes unit or integration tests for changed behaviors.
- [x] Added an internal doc comment explaining the projection boundary.
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is not a breaking change. Previously ignored explicit variants now affect rendering.

## Validation

- Full Remix suite: 2,748 tests passed.
- Flutter analysis and repository generation check passed.
- Five new cases cover light/dark contexts, explicit item overrides, live theme
  changes with the menu open, checkbox-specific typography and hover entry/exit.
- The original regression failed against the previous renderer.
- Exact-head CI and showcase workflows passed at `37d5b4b00de22aa142d74e38b629249c34acf645`.

## Visual evidence

Identical 800×480 Flutter fixture with a dark context requesting 24px item labels.

Before:
![Menu ignores root font variant](https://github.com/user-attachments/assets/fe657d4e-ae12-4d63-a440-bb71e26bc62d)

After:
![Menu honors root font variant](https://github.com/user-attachments/assets/870fcc65-3cb9-4ca1-bf32-be0bddda82d2)
