### PR TITLE
fix(data-table): preserve root variants in cell styles

### DIFF
--- a/packages/remix/lib/src/components/data_table/data_table_widget.dart
+++ b/packages/remix/lib/src/components/data_table/data_table_widget.dart
@@ -516,46 +516,43 @@ class _DataTableStyles {
   /// Values resolved once, outside any row's widget-state scope.
   final DataTableSpec spec;
 
-  /// Resolves [prop] in [context] so widget-state variants see the row's
-  /// states, falling back to the table-level value when there is no styler.
-  V _resolve<V>(BuildContext context, Prop<V>? prop, V fallback) {
-    if (styler == null || prop == null) return fallback;
+  DataTableSpec resolve(BuildContext context) => styler == null
+      ? spec
+      : _DataTableRegionProjection(styler!, spec).build(context).spec;
+}
 
-    return MixOps.resolve(context, prop) ?? fallback;
-  }
+/// Applies root variants before resolving regions against the cell's state.
+final class _DataTableRegionProjection extends DataTableStyler {
+  _DataTableRegionProjection(this.source, this.fallback)
+    : super.create(variants: source.$variants);
 
-  StyleSpec<BoxSpec> headerRow(BuildContext context) =>
-      _resolve(context, styler?.$headerRow, spec.headerRow);
+  final DataTableStyler source;
+  final DataTableSpec fallback;
 
-  /// The final row merges [DataTableSpec.lastBodyRow] over the shared row
-  /// chrome; every other row uses the shared chrome alone.
-  StyleSpec<BoxSpec> bodyRow(BuildContext context, {required bool isLast}) {
-    if (!isLast) return _resolve(context, styler?.$bodyRow, spec.bodyRow);
+  @override
+  DataTableStyler merge(DataTableStyler? other) =>
+      _DataTableRegionProjection(source.merge(other), fallback);
 
-    return _resolve(
-      context,
-      MixOps.merge(styler?.$bodyRow, styler?.$lastBodyRow),
-      spec.lastBodyRow ?? spec.bodyRow,
-    );
-  }
+  @override
+  StyleSpec<DataTableSpec> resolve(BuildContext context) => StyleSpec(
+    spec: fallback.copyWith(
+      headerRow: MixOps.resolve(context, source.$headerRow),
+      bodyRow: MixOps.resolve(context, source.$bodyRow),
+      lastBodyRow: MixOps.resolve(
+        context,
+        MixOps.merge(source.$bodyRow, source.$lastBodyRow),
+      ),
+      headerCell: MixOps.resolve(context, source.$headerCell),
+      bodyCell: MixOps.resolve(context, source.$bodyCell),
+      selectionCell: MixOps.resolve(context, source.$selectionCell),
+      headerLabel: MixOps.resolve(context, source.$headerLabel),
+      cellText: MixOps.resolve(context, source.$cellText),
+      sortIcon: MixOps.resolve(context, source.$sortIcon),
+    ),
+  );
 
-  StyleSpec<BoxSpec> headerCell(BuildContext context) =>
-      _resolve(context, styler?.$headerCell, spec.headerCell);
-
-  StyleSpec<BoxSpec> bodyCell(BuildContext context) =>
-      _resolve(context, styler?.$bodyCell, spec.bodyCell);
-
-  StyleSpec<BoxSpec> selectionCell(BuildContext context) =>
-      _resolve(context, styler?.$selectionCell, spec.selectionCell);
-
-  StyleSpec<TextSpec> headerLabel(BuildContext context) =>
-      _resolve(context, styler?.$headerLabel, spec.headerLabel);
-
-  StyleSpec<TextSpec> cellText(BuildContext context) =>
-      _resolve(context, styler?.$cellText, spec.cellText);
-
-  StyleSpec<IconSpec> sortIcon(BuildContext context) =>
-      _resolve(context, styler?.$sortIcon, spec.sortIcon);
+  @override
+  List<Object?> get props => [source, fallback];
 }
 
 /// Renders one table: header, body, optional empty surface, optional footer.
@@ -1037,8 +1034,8 @@ class _DataTableHeaderCell extends StatelessWidget {
   final _DataTableSortIcons? sortIcons;
   final bool useSelectionCell;
 
-  Widget _buildContent(BuildContext context) {
-    final headerStyle = styles.headerLabel(context);
+  Widget _buildContent(DataTableSpec resolved) {
+    final headerStyle = resolved.headerLabel;
     // A custom header inherits the header typography the way Radix cascades
     // `th` styles onto arbitrary markup, without excluding its own semantics.
     final content = child == null
@@ -1060,9 +1057,9 @@ class _DataTableHeaderCell extends StatelessWidget {
                 RemixPathGlyph.caretDown,
               null => RemixPathGlyph.caretSort,
             },
-            styleSpec: styles.sortIcon(context),
+            styleSpec: resolved.sortIcon,
           )
-        : StyledIcon(icon: icon, styleSpec: styles.sortIcon(context));
+        : StyledIcon(icon: icon, styleSpec: resolved.sortIcon);
 
     return Row(
       mainAxisSize: MainAxisSize.min,
@@ -1079,15 +1076,16 @@ class _DataTableHeaderCell extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     Widget cell = Builder(
-      builder: (context) => _DataTableCellSurface(
-        row: styles.headerRow(context),
-        cell: useSelectionCell
-            ? styles.selectionCell(context)
-            : styles.headerCell(context),
-        alignment: alignment,
-        minHeight: minHeight,
-        child: _buildContent(context),
-      ),
+      builder: (context) {
+        final resolved = styles.resolve(context);
+        return _DataTableCellSurface(
+          row: resolved.headerRow,
+          cell: useSelectionCell ? resolved.selectionCell : resolved.headerCell,
+          alignment: alignment,
+          minHeight: minHeight,
+          child: _buildContent(resolved),
+        );
+      },
     );
 
     if (onSort != null) {
@@ -1153,18 +1151,23 @@ class _DataTableBodyCell extends StatelessWidget {
       child: WidgetStateProvider(
         states: states,
         child: Builder(
-          builder: (context) => _DataTableCellSurface(
-            row: styles.bodyRow(context, isLast: isLastRow),
-            cell: useSelectionCell
-                ? styles.selectionCell(context)
-                : styles.bodyCell(context),
-            alignment: alignment,
-            minHeight: minHeight,
-            child: RemixDefaultContentStyle(
-              text: styles.cellText(context),
-              child: child,
-            ),
-          ),
+          builder: (context) {
+            final resolved = styles.resolve(context);
+            return _DataTableCellSurface(
+              row: isLastRow
+                  ? (resolved.lastBodyRow ?? resolved.bodyRow)
+                  : resolved.bodyRow,
+              cell: useSelectionCell
+                  ? resolved.selectionCell
+                  : resolved.bodyCell,
+              alignment: alignment,
+              minHeight: minHeight,
+              child: RemixDefaultContentStyle(
+                text: resolved.cellText,
+                child: child,
+              ),
+            );
+          },
         ),
       ),
     );

--- a/packages/remix/test/components/data_table/root_variant_test.dart
+++ b/packages/remix/test/components/data_table/root_variant_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remix/remix.dart';
+
+void main() {
+  testWidgets('root context updates preserve nested selected typography', (
+    tester,
+  ) async {
+    final brightness = ValueNotifier(Brightness.light);
+    addTearDown(brightness.dispose);
+    final style = DataTableStyler()
+        .cellText(TextStyler().fontSize(12))
+        .onDark(
+          DataTableStyler().cellText(
+            TextStyler()
+                .fontSize(24)
+                .onSelected(TextStyler().fontWeight(FontWeight.w700)),
+          ),
+        );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ValueListenableBuilder<Brightness>(
+          valueListenable: brightness,
+          builder: (_, value, _) => MediaQuery(
+            data: MediaQueryData(platformBrightness: value),
+            child: Scaffold(
+              body: RemixDataTable<String>(
+                rows: const ['Ada', 'Blaise'],
+                columns: [
+                  RemixDataTableColumn<String>(
+                    id: 'name',
+                    label: 'Name',
+                    cellBuilder: (_, row) => Text(row),
+                  ),
+                ],
+                rowId: (row) => row,
+                selectedRowIds: const {'Ada'},
+                onSelectionChanged: (_) {},
+                style: style,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    TextStyle? rendered(String label) => tester
+        .widget<RichText>(
+          find.descendant(
+            of: find.text(label),
+            matching: find.byType(RichText),
+          ),
+        )
+        .text
+        .style;
+    expect(rendered('Ada')?.fontSize, 12);
+    brightness.value = Brightness.dark;
+    await tester.pump();
+    expect(rendered('Ada')?.fontSize, 24);
+    expect(rendered('Blaise')?.fontSize, 24);
+    expect(rendered('Ada')?.fontWeight, FontWeight.w700);
+    expect(rendered('Blaise')?.fontWeight, isNot(FontWeight.w700));
+    brightness.value = Brightness.light;
+    await tester.pump();
+    expect(rendered('Ada')?.fontSize, 12);
+    expect(rendered('Ada')?.fontWeight, isNot(FontWeight.w700));
+  });
+
+  for (final dark in [false, true]) {
+    for (final raw in [false, true]) {
+      testWidgets('root variants dark=$dark raw=$raw', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            builder: (_, child) => MediaQuery(
+              data: MediaQueryData(
+                platformBrightness: dark ? Brightness.dark : Brightness.light,
+              ),
+              child: child!,
+            ),
+            home: Scaffold(
+              body: RemixDataTable<String>(
+                rows: const ['Ada'],
+                columns: [
+                  RemixDataTableColumn<String>(
+                    id: 'name',
+                    label: 'Name',
+                    cellBuilder: (_, row) => Text(row),
+                  ),
+                ],
+                style: DataTableStyler()
+                    .cellText(TextStyler().fontSize(12))
+                    .onDark(
+                      DataTableStyler().cellText(TextStyler().fontSize(24)),
+                    ),
+                styleSpec: raw
+                    ? const DataTableSpec(
+                        cellText: StyleSpec(
+                          spec: TextSpec(style: TextStyle(fontSize: 19)),
+                        ),
+                      )
+                    : null,
+              ),
+            ),
+          ),
+        );
+        final text = tester.widget<RichText>(
+          find.descendant(
+            of: find.text('Ada'),
+            matching: find.byType(RichText),
+          ),
+        );
+        expect(
+          text.text.style?.fontSize,
+          raw
+              ? 19
+              : dark
+              ? 24
+              : 12,
+        );
+      });
+    }
+  }
+
+  testWidgets('root dark variant reaches rendered cell text', (tester) async {
+    final style = DataTableStyler()
+        .cellText(TextStyler().fontSize(12))
+        .onDark(DataTableStyler().cellText(TextStyler().fontSize(24)));
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(brightness: Brightness.dark),
+        builder: (_, child) => MediaQuery(
+          data: const MediaQueryData(platformBrightness: Brightness.dark),
+          child: child!,
+        ),
+        home: Scaffold(
+          body: Builder(
+            builder: (context) {
+              expect(
+                style.build(context).spec.cellText.spec.style?.fontSize,
+                24,
+              );
+              return RemixDataTable<String>(
+                rows: const ['Ada'],
+                columns: [
+                  RemixDataTableColumn<String>(
+                    id: 'name',
+                    label: 'Name',
+                    cellBuilder: (_, row) => Text(row),
+                  ),
+                ],
+                style: style,
+              );
+            },
+          ),
+        ),
+      ),
+    );
+    final text = tester.widget<RichText>(
+      find.descendant(of: find.text('Ada'), matching: find.byType(RichText)),
+    );
+    expect(text.text.style?.fontSize, 24);
+  });
+}


### PR DESCRIPTION
## Description

DataTable re-resolved base region properties without applying root variants first. A dark-context cell font could resolve to 24px at the table but render at its base 12px.

Apply root variants through Mix before resolving cell regions, once per cell. Preserve raw-spec precedence, nested row states and existing last-row composition. No public API or new renderer is added.

## Related Issues

No linked issue; found during the component property-forwarding audit.

## Checklist

- [x] My PR includes regression tests for the root-variant correction and override behavior.
- [x] Added a doc comment explaining the private projection.
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this does not require callers to update their code; previously ignored root settings now apply.

## Validation

- 74 DataTable tests passed, including six new cases covering a root-resolution control, light/dark contexts, raw-spec precedence and live context changes with nested selection typography.
- Targeted analysis passed; diff check passed.
- Real before/after Flutter captures passed and were inspected.
- Local repository generation stopped with a disk-space error; its subsequent full-test and full-analysis steps did not run. Generated files removed by that failed build were restored unchanged.
- Keep draft until required repository CI passes at the reviewed head. Local full-gate success is not claimed.

## Visual evidence

Identical 800×480 synthetic dark-context table, requesting 24px cell text. Before/after screenshots:

Before:
![DataTable ignores root typography](https://github.com/user-attachments/assets/41f98e4b-59f2-4cfb-9c4c-d20fb05a6846)

After:
![DataTable honors root typography](https://github.com/user-attachments/assets/d2d0a61c-1446-4623-af65-bbc56c32340a)
