### PR TITLE
fix(menu): preserve inherited root styles during item resolution

### DIFF
--- a/packages/remix/lib/src/components/menu/menu_widget.dart
+++ b/packages/remix/lib/src/components/menu/menu_widget.dart
@@ -588,22 +588,50 @@ final class _RemixMenuItemStyles {
       };
     }
 
-    final fluentStyle = styler!;
+    return _MenuItemProjection(
+      styler!,
+      kind,
+      itemStyle,
+    ).build(context).spec.item;
+  }
+}
+
+/// Projects an item only after Mix has merged the menu's active variants.
+final class _MenuItemProjection extends MenuStyler {
+  _MenuItemProjection(this.source, this.kind, this.itemStyle)
+    : super.create(variants: source.$variants);
+
+  final MenuStyler source;
+  final _RemixMenuItemKind kind;
+  final MenuItemStyler itemStyle;
+
+  @override
+  MenuStyler merge(MenuStyler? other) =>
+      _MenuItemProjection(source.merge(other), kind, itemStyle);
+
+  @override
+  StyleSpec<MenuSpec> resolve(BuildContext context) {
     final semanticStyle = switch (kind) {
       .ordinary => null,
-      .checkbox => fluentStyle.$checkboxItem,
-      .radio => fluentStyle.$radioItem,
-      .submenu => fluentStyle.$submenuItem,
+      .checkbox => source.$checkboxItem,
+      .radio => source.$radioItem,
+      .submenu => source.$submenuItem,
     };
-    final menuStyle = MixOps.merge(fluentStyle.$item, semanticStyle);
     final mergedStyle = MixOps.merge(
-      menuStyle,
+      MixOps.merge(source.$item, semanticStyle),
       Prop.maybeMix<StyleSpec<MenuItemSpec>>(itemStyle),
     );
-
-    return MixOps.resolve(context, mergedStyle) ??
-        const StyleSpec(spec: MenuItemSpec());
+    return StyleSpec(
+      spec: MenuSpec(
+        item:
+            MixOps.resolve(context, mergedStyle) ??
+            const StyleSpec(spec: MenuItemSpec()),
+      ),
+    );
   }
+
+  @override
+  List<Object?> get props => [source, kind, itemStyle];
 }
 
 /// One renderer intentionally serves root and recursive submenu overlays so

--- a/packages/remix/lib/src/components/menu/menu_widget.dart
+++ b/packages/remix/lib/src/components/menu/menu_widget.dart
@@ -502,6 +502,10 @@ class _RemixMenuState<T> extends State<RemixMenu<T>> {
           style: style,
           styleSpec: widget.styleSpec,
           builder: (context, spec) {
+            final inherited = Style.maybeOf<MenuSpec>(context);
+            final effectiveStyle = inherited is MenuStyler
+                ? inherited.merge(style)
+                : style;
             return _RemixMenuItemsPanel<T>(
               items: widget.items,
               overlayStyleSpec: spec.overlay,
@@ -509,7 +513,7 @@ class _RemixMenuState<T> extends State<RemixMenu<T>> {
               dividerStyleSpec: spec.divider,
               hasRootSelectionCallback: widget.onSelected != null,
               itemStyles: widget.styleSpec == null
-                  ? _RemixMenuItemStyles.fromStyler(style)
+                  ? _RemixMenuItemStyles.fromStyler(effectiveStyle)
                   : _RemixMenuItemStyles.fromSpec(spec),
             );
           },

--- a/packages/remix/test/components/menu/menu_context_variant_test.dart
+++ b/packages/remix/test/components/menu/menu_context_variant_test.dart
@@ -1,0 +1,159 @@
+import 'dart:ui' show PointerDeviceKind;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remix/remix.dart';
+
+void main() {
+  testWidgets(
+    'open menu tracks theme and preserves item hover and kind styles',
+    (tester) async {
+      final brightness = ValueNotifier(Brightness.light);
+      addTearDown(brightness.dispose);
+      final style = MenuStyler()
+          .item(MenuItemStyler().label(TextStyler().fontSize(12)))
+          .onDark(
+            MenuStyler()
+                .item(
+                  MenuItemStyler()
+                      .label(TextStyler().fontSize(24))
+                      .onHovered(
+                        MenuItemStyler().label(TextStyler().fontSize(30)),
+                      ),
+                )
+                .checkboxItem(
+                  MenuItemStyler().label(TextStyler().fontSize(26)),
+                ),
+          );
+      await tester.pumpWidget(
+        MixScope.empty(
+          child: MaterialApp(
+            builder: (context, child) => ValueListenableBuilder(
+              valueListenable: brightness,
+              builder: (context, value, _) => MediaQuery(
+                data: MediaQueryData(platformBrightness: value),
+                child: child!,
+              ),
+            ),
+            home: Scaffold(
+              body: Center(
+                child: RemixMenu<String>(
+                  trigger: const RemixMenuTrigger(label: 'Options'),
+                  onSelected: (_) {},
+                  items: [
+                    const RemixMenuItem(value: 'copy', label: 'Copy'),
+                    RemixMenuCheckboxItem(
+                      value: 'check',
+                      label: 'Checked',
+                      checked: true,
+                      onChanged: (_) {},
+                    ),
+                  ],
+                  style: style,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Options'));
+      await tester.pumpAndSettle();
+      double? fontSize(String label) => tester
+          .widget<RichText>(
+            find.descendant(
+              of: find.text(label),
+              matching: find.byType(RichText),
+            ),
+          )
+          .text
+          .style
+          ?.fontSize;
+      expect(fontSize('Copy'), 12);
+      brightness.value = Brightness.dark;
+      await tester.pumpAndSettle();
+      expect(fontSize('Copy'), 24);
+      expect(fontSize('Checked'), 26);
+      final mouse = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await mouse.addPointer(location: Offset.zero);
+      await mouse.moveTo(tester.getCenter(find.text('Copy')));
+      await tester.pumpAndSettle();
+      expect(fontSize('Copy'), 30);
+      await mouse.removePointer();
+      await tester.pumpAndSettle();
+      expect(fontSize('Copy'), 24);
+      brightness.value = Brightness.light;
+      await tester.pumpAndSettle();
+      expect(fontSize('Copy'), 12);
+      expect(fontSize('Checked'), 12);
+    },
+  );
+  for (final brightness in Brightness.values) {
+    for (final overrideSize in <double?>[null, 32]) {
+      testWidgets(
+        'menu root variant $brightness and item override $overrideSize',
+        (tester) async {
+          final style = MenuStyler()
+              .item(MenuItemStyler().label(TextStyler().fontSize(12)))
+              .onDark(
+                MenuStyler().item(
+                  MenuItemStyler().label(TextStyler().fontSize(24)),
+                ),
+              );
+          double? resolvedRootSize;
+          await tester.pumpWidget(
+            MixScope.empty(
+              child: MaterialApp(
+                builder: (context, child) => MediaQuery(
+                  data: MediaQueryData(platformBrightness: brightness),
+                  child: child!,
+                ),
+                home: Scaffold(
+                  body: Center(
+                    child: Column(
+                      children: [
+                        StyleBuilder<MenuSpec>(
+                          style: style,
+                          builder: (context, spec) {
+                            resolvedRootSize =
+                                spec.item.spec.label.spec.style?.fontSize;
+                            return const SizedBox();
+                          },
+                        ),
+                        RemixMenu<String>(
+                          trigger: const RemixMenuTrigger(label: 'Options'),
+                          items: [
+                            RemixMenuItem(
+                              value: 'copy',
+                              label: 'Copy',
+                              style: overrideSize == null
+                                  ? const MenuItemStyler.create()
+                                  : MenuItemStyler().label(
+                                      TextStyler().fontSize(overrideSize),
+                                    ),
+                            ),
+                          ],
+                          style: style,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          );
+          await tester.pumpAndSettle();
+          final expectedSize = brightness == Brightness.dark ? 24.0 : 12.0;
+          expect(resolvedRootSize, expectedSize);
+          await tester.tap(find.text('Options'));
+          await tester.pumpAndSettle();
+          final text = tester.widget<RichText>(
+            find.descendant(
+              of: find.text('Copy'),
+              matching: find.byType(RichText),
+            ),
+          );
+          expect(text.text.style?.fontSize, overrideSize ?? expectedSize);
+        },
+      );
+    }
+  }
+}

--- a/packages/remix/test/components/menu/menu_inherited_style_test.dart
+++ b/packages/remix/test/components/menu/menu_inherited_style_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:remix/remix.dart';
+
+void main() {
+  for (final raw in [false, true]) {
+    testWidgets('menu inherits root item styles unless raw=$raw', (
+      tester,
+    ) async {
+      final brightness = ValueNotifier(Brightness.light);
+      addTearDown(brightness.dispose);
+      final inherited = MenuStyler()
+          .item(
+            MenuItemStyler().label(
+              TextStyler().fontFamily('InheritedFont').fontSize(19),
+            ),
+          )
+          .onDark(
+            MenuStyler().item(
+              MenuItemStyler().label(TextStyler().fontSize(27)),
+            ),
+          );
+      await tester.pumpWidget(
+        MixScope.empty(
+          child: StyleProvider<MenuSpec>(
+            style: inherited,
+            child: MaterialApp(
+              builder: (_, child) => ValueListenableBuilder<Brightness>(
+                valueListenable: brightness,
+                builder: (_, value, _) => MediaQuery(
+                  data: MediaQueryData(platformBrightness: value),
+                  child: child!,
+                ),
+              ),
+              home: Scaffold(
+                body: Center(
+                  child: RemixMenu<String>(
+                    trigger: const RemixMenuTrigger(label: 'Options'),
+                    onSelected: (_) {},
+                    items: [
+                      const RemixMenuItem(
+                        value: 'inherited',
+                        label: 'Inherited',
+                      ),
+                      RemixMenuItem(
+                        value: 'override',
+                        label: 'Item override',
+                        style: MenuItemStyler().label(
+                          TextStyler().fontSize(31),
+                        ),
+                      ),
+                    ],
+                    style: MenuStyler().item(
+                      MenuItemStyler().label(
+                        TextStyler().color(Colors.red),
+                      ),
+                    ),
+                    styleSpec: raw
+                        ? const MenuSpec(
+                            item: StyleSpec(
+                              spec: MenuItemSpec(
+                                label: StyleSpec(
+                                  spec: TextSpec(
+                                    style: TextStyle(
+                                      fontFamily: 'RawFont',
+                                      fontSize: 21,
+                                      color: Colors.blue,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          )
+                        : null,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.tap(find.text('Options'));
+      await tester.pumpAndSettle();
+      TextStyle? rendered(String label) => tester
+          .widget<RichText>(
+            find.descendant(
+              of: find.text(label),
+              matching: find.byType(RichText),
+            ),
+          )
+          .text
+          .style;
+      for (final value in [
+        Brightness.light,
+        Brightness.dark,
+        Brightness.light,
+      ]) {
+        brightness.value = value;
+        await tester.pumpAndSettle();
+        expect(
+          rendered('Inherited')?.fontSize,
+          raw ? 21 : (value == Brightness.dark ? 27 : 19),
+        );
+        expect(
+          rendered('Inherited')?.fontFamily,
+          raw ? 'RawFont' : 'InheritedFont',
+        );
+        expect(
+          rendered('Inherited')?.color,
+          raw ? Colors.blue : Colors.red,
+        );
+        expect(rendered('Item override')?.fontSize, raw ? 21 : 31);
+      }
+      expect(tester.takeException(), isNull);
+    });
+  }
+}


### PR DESCRIPTION
## Description

Menu items lost inherited typography and root context variants because their resolver received only the local `MenuStyler`. Pass the inherited-plus-local style through the existing item projection. The root builder still receives the original local style, preserving precedence and avoiding a second inherited merge.

## Related Issues

Follow-up to merged #201. This PR now targets `main` and contains only the remaining inherited-style fix and its regression tests.

## Validation

- Regression coverage checks rendered typography, live light/dark updates while the menu stays open, explicit item overrides, and authoritative raw specs.
- The recorded test-only CI baseline failed with expected font size 19 versus actual 14; the raw-spec case passed.
- Combined local Flutter package tests passed with this fix and the other six reviewed Remix feature PRs applied together.
- GitHub CI passed on the updated branch after merging current main.

## Checklist

- [x] Regression failure observed before the fix.
- [x] Existing projection and raw-spec behavior preserved.
- [x] Local Flutter package tests passed.
- [x] Documentation accurately describes the current base and validation.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No public API change; inherited menu styles now follow the existing style inheritance contract.
