### PR TITLE
ci: cancel superseded pull request runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: pr-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   cli-windows:
     name: Verify the CLI with the Windows Flutter SDK

--- a/.github/workflows/deploy_web.yml
+++ b/.github/workflows/deploy_web.yml
@@ -15,7 +15,7 @@ permissions:
 # Allow only one concurrent Pages run per branch or pull request
 concurrency:
   group: "pages-${{ github.ref }}"
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,6 +7,10 @@ on:
       - edited
       - synchronize
 
+concurrency:
+  group: pr-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+
 jobs:
   main:
     name: Validate PR title


### PR DESCRIPTION
## Description

New pushes currently leave superseded pull-request runs executing. Cancel older runs of each changed workflow for the same PR so runner time is spent on the latest commit. Other PRs and non-PR runs retain their existing behavior. The Pages workflow cancels only PR builds; its non-PR deployment serialization is preserved.

- `.github/workflows/pr.yml`
- `.github/workflows/ci.yaml`
- `.github/workflows/deploy_web.yml`

## Related Issues

No linked issue; CI maintenance.

## Checklist

- [x] Workflow YAML and structural checks passed; validation details below.
- [ ] Live cancellation and applicable CI verified.
- Documentation and changelog updates are not applicable to this workflow-only change.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is not a breaking change.

## Validation

- YAML parsing and structural comparison passed: only `concurrency` changed.
- `git diff --no-index --check` found no whitespace errors.
- `actionlint -shellcheck= -pyflakes=` passed for every changed workflow.

Application suites were not run locally for this workflow-only patch. Keep this PR in draft until applicable CI completes. Live cancellation behavior remains to be checked by pushing again while a PR run is active; a `pull_request_target` workflow uses the base-branch definition until this change is merged.


## CI verification snapshot

All reported checks for commit `3353c824a2c608433d2313904def4b8a2178dd87` have completed successfully or were intentionally skipped, as of 2026-09-11T16:04:57+00:00. No failing or pending checks were reported.
