### PR TITLE
feat(remix_cli): chart colors from theme tokens, shared constraints in melos

### DIFF
--- a/apps/playground/lib/ui/components/chart.dart
+++ b/apps/playground/lib/ui/components/chart.dart
@@ -19,25 +19,13 @@ const _barRadiusToken = ContextToken<BorderRadius>(_resolveBarRadius);
 
 /// Returns the categorical palette shared by this application's charts.
 ///
-/// The first color follows the application's `primary` token. The remaining
-/// colors are local values chosen for separation on the active background.
-/// Edit the two lists below to change every chart, or pass `palette` to one
-/// recipe or generated widget for a local override.
-///
-/// The returned list removes duplicates. A brand whose primary matches one of
-/// the fixed colors therefore keeps a useful palette instead of drawing two
-/// series with the same paint.
-List<Color> resolvePlaygroundChartPalette(BuildContext context) {
-  final background = PlaygroundTokens.background.resolve(context);
-  final fixed = background.computeLuminance() < _darkBackgroundLuminance
-      ? _darkCategoricalColors
-      : _lightCategoricalColors;
-
-  return List<Color>.unmodifiable(<Color>{
-    PlaygroundTokens.primary.resolve(context),
-    ...fixed,
-  });
-}
+/// The colors are the theme's `chart1` through `chart5` tokens in series
+/// order, so editing them in `PlaygroundThemeData` restyles every chart.
+/// Pass `palette` to one recipe or generated widget for a local override.
+List<Color> resolvePlaygroundChartPalette(BuildContext context) =>
+    List<Color>.unmodifiable([
+      for (final token in PlaygroundTokens.chart) token.resolve(context),
+    ]);
 
 /// The application's line and area chart recipe.
 ///
@@ -140,33 +128,6 @@ PieChartStyler playgroundPieChartStyle({
     .tooltip(_chartTooltipStyle())
     .merge(PieChartStyler.create(palette: _paletteProp(palette)))
     .merge(style);
-
-/// Luminance below which the dark categorical palette is used.
-///
-/// This is the WCAG midpoint where white becomes the stronger contrasting
-/// choice than black. It lets a custom dark background select the right list
-/// without adding a brightness field to the existing theme contract.
-const _darkBackgroundLuminance = 0.179;
-
-/// Categorical colors for a light page, excluding the theme's primary color.
-const _lightCategoricalColors = <Color>[
-  Color(0xFF2563EB),
-  Color(0xFFC2410C),
-  Color(0xFF047857),
-  Color(0xFF7E22CE),
-  Color(0xFFBE123C),
-  Color(0xFF0E7490),
-];
-
-/// Categorical colors for a dark page, excluding the theme's primary color.
-const _darkCategoricalColors = <Color>[
-  Color(0xFF60A5FA),
-  Color(0xFFFB923C),
-  Color(0xFF34D399),
-  Color(0xFFC084FC),
-  Color(0xFFFB7185),
-  Color(0xFF22D3EE),
-];
 
 /// Width of a line series.
 const _lineWidth = 2.0;

--- a/apps/playground/lib/ui/theme/theme_data.dart
+++ b/apps/playground/lib/ui/theme/theme_data.dart
@@ -27,6 +27,11 @@ class PlaygroundThemeData {
     required this.destructiveForeground,
     required this.border,
     required this.focusRing,
+    required this.chart1,
+    required this.chart2,
+    required this.chart3,
+    required this.chart4,
+    required this.chart5,
     required this.radius,
   });
 
@@ -46,6 +51,11 @@ class PlaygroundThemeData {
       destructiveForeground = const Color(0xFFFFFFFF),
       border = const Color(0xFFE5E5E5),
       focusRing = const Color(0xFF4F46E5),
+      chart1 = const Color(0xFF2563EB),
+      chart2 = const Color(0xFFC2410C),
+      chart3 = const Color(0xFF047857),
+      chart4 = const Color(0xFF7E22CE),
+      chart5 = const Color(0xFFBE123C),
       radius = const Radius.circular(8);
 
   /// The neutral dark theme.
@@ -64,6 +74,11 @@ class PlaygroundThemeData {
       destructiveForeground = const Color(0xFFFFFFFF),
       border = const Color(0xFF404040),
       focusRing = const Color(0xFFA3A3A3),
+      chart1 = const Color(0xFF60A5FA),
+      chart2 = const Color(0xFFFB923C),
+      chart3 = const Color(0xFF34D399),
+      chart4 = const Color(0xFFC084FC),
+      chart5 = const Color(0xFFFB7185),
       radius = const Radius.circular(8);
 
   /// Value for [PlaygroundTokens.background].
@@ -108,6 +123,21 @@ class PlaygroundThemeData {
   /// Value for [PlaygroundTokens.focusRing].
   final Color focusRing;
 
+  /// Value for [PlaygroundTokens.chart1].
+  final Color chart1;
+
+  /// Value for [PlaygroundTokens.chart2].
+  final Color chart2;
+
+  /// Value for [PlaygroundTokens.chart3].
+  final Color chart3;
+
+  /// Value for [PlaygroundTokens.chart4].
+  final Color chart4;
+
+  /// Value for [PlaygroundTokens.chart5].
+  final Color chart5;
+
   /// Value for [PlaygroundTokens.radius].
   final Radius radius;
 
@@ -131,6 +161,11 @@ class PlaygroundThemeData {
         PlaygroundTokens.destructiveForeground: destructiveForeground,
         PlaygroundTokens.border: border,
         PlaygroundTokens.focusRing: focusRing,
+        PlaygroundTokens.chart1: chart1,
+        PlaygroundTokens.chart2: chart2,
+        PlaygroundTokens.chart3: chart3,
+        PlaygroundTokens.chart4: chart4,
+        PlaygroundTokens.chart5: chart5,
         PlaygroundTokens.radius: radius,
       });
 
@@ -150,6 +185,11 @@ class PlaygroundThemeData {
     Color? destructiveForeground,
     Color? border,
     Color? focusRing,
+    Color? chart1,
+    Color? chart2,
+    Color? chart3,
+    Color? chart4,
+    Color? chart5,
     Radius? radius,
   }) => PlaygroundThemeData(
     background: background ?? this.background,
@@ -166,6 +206,11 @@ class PlaygroundThemeData {
     destructiveForeground: destructiveForeground ?? this.destructiveForeground,
     border: border ?? this.border,
     focusRing: focusRing ?? this.focusRing,
+    chart1: chart1 ?? this.chart1,
+    chart2: chart2 ?? this.chart2,
+    chart3: chart3 ?? this.chart3,
+    chart4: chart4 ?? this.chart4,
+    chart5: chart5 ?? this.chart5,
     radius: radius ?? this.radius,
   );
 
@@ -184,6 +229,11 @@ class PlaygroundThemeData {
     destructiveForeground,
     border,
     focusRing,
+    chart1,
+    chart2,
+    chart3,
+    chart4,
+    chart5,
     radius,
   ];
 

--- a/apps/playground/lib/ui/theme/tokens.dart
+++ b/apps/playground/lib/ui/theme/tokens.dart
@@ -70,8 +70,31 @@ abstract final class PlaygroundTokens {
   /// follows; nothing else reads this token.
   static const focusRing = ColorToken('ui.color.focus-ring');
 
+  /// First categorical chart series color.
+  ///
+  /// Charts assign [chart1] through [chart5] to series in order; see [chart].
+  /// The shipped themes keep one hue per series in both brightnesses, and
+  /// every value clears 4.5:1 against [background]. That also keeps pie labels,
+  /// which are drawn in [background], readable on their slice.
+  static const chart1 = ColorToken('ui.color.chart-1');
+
+  /// Second categorical chart series color. See [chart1].
+  static const chart2 = ColorToken('ui.color.chart-2');
+
+  /// Third categorical chart series color. See [chart1].
+  static const chart3 = ColorToken('ui.color.chart-3');
+
+  /// Fourth categorical chart series color. See [chart1].
+  static const chart4 = ColorToken('ui.color.chart-4');
+
+  /// Fifth categorical chart series color. See [chart1].
+  static const chart5 = ColorToken('ui.color.chart-5');
+
   /// Corner radius shared by the application's controls.
   static const radius = RadiusToken('ui.radius');
+
+  /// The chart series colors in the order charts assign them.
+  static const chart = <ColorToken>[chart1, chart2, chart3, chart4, chart5];
 
   /// Every color token this layer defines, in declaration order.
   ///
@@ -92,5 +115,10 @@ abstract final class PlaygroundTokens {
     destructiveForeground,
     border,
     focusRing,
+    chart1,
+    chart2,
+    chart3,
+    chart4,
+    chart5,
   ];
 }

--- a/docs/open-code.mdx
+++ b/docs/open-code.mdx
@@ -495,6 +495,9 @@ look, then `--overwrite` deliberately.
 Generated adapters are not your problem. `button.g.dart` is regenerated
 whenever its authored source is rewritten or the adapter is missing, and the
 CLI verifies the file exists afterwards rather than assuming the build worked.
+The current `mix_generator` writes `this.` qualifiers that `flutter_lints`
+reports as infos, so exclude `lib/ui/**/*.g.dart` under `analyzer: exclude:`
+in `analysis_options.yaml`.
 </Note>
 
 ### Removing an item
@@ -617,9 +620,10 @@ stacked, or floating. A positive `centerRadius` makes a pie chart a donut.
 
 `mix_chart` retains the hard contract: data validation, rendering, pointer
 interaction, transitions, tooltips, and chart semantics. Your copied file owns
-the categorical palette, axes, grid, shared series geometry, and tooltip
-appearance. It reads only the current open-code theme tokens, so adding it does
-not require replacing an older customized Theme.
+the axes, grid, shared series geometry, and tooltip appearance. Series colors
+come from the Theme's `chart1` to `chart5` tokens. A Theme installed by an
+earlier CLI build lacks them: add the five tokens to `tokens.dart` and
+`theme_data.dart` before adding `chart`.
 
 Import chart data directly and give the chart finite dimensions:
 
@@ -647,10 +651,11 @@ final chart = SizedBox(
 );
 ```
 
-The default palette follows `UiTokens.primary`, selects readable light or dark
-categorical colors from `UiTokens.background`, and removes duplicates. Edit
-`resolveUiChartPalette` for a design-system change. Pass `palette` or `style`
-for a one-chart override. The UI barrel does not re-export `mix_chart`.
+The palette is `UiTokens.chart`: `chart1` to `chart5` in series order. The
+shipped light and dark values keep each series' hue and clear 4.5:1 against
+the page background. Edit them in `UiThemeData` for a design-system change.
+Pass `palette` or `style` for a one-chart override. The UI barrel does not
+re-export `mix_chart`.
 
 `remix add icons` also declares `remix_ui_icons` and gives you a small alias
 surface to evolve with the application. Import

--- a/open_code/fixture/test/open_code_test.dart
+++ b/open_code/fixture/test/open_code_test.dart
@@ -26,6 +26,11 @@ void main() {
       expect(theme.destructiveForeground, const Color(0xFFFFFFFF));
       expect(theme.border, const Color(0xFFE5E5E5));
       expect(theme.focusRing, const Color(0xFF737373));
+      expect(theme.chart1, const Color(0xFF2563EB));
+      expect(theme.chart2, const Color(0xFFC2410C));
+      expect(theme.chart3, const Color(0xFF047857));
+      expect(theme.chart4, const Color(0xFF7E22CE));
+      expect(theme.chart5, const Color(0xFFBE123C));
       expect(theme.radius, const Radius.circular(8));
     });
 
@@ -46,6 +51,11 @@ void main() {
       expect(theme.destructiveForeground, const Color(0xFFFFFFFF));
       expect(theme.border, const Color(0xFF404040));
       expect(theme.focusRing, const Color(0xFFA3A3A3));
+      expect(theme.chart1, const Color(0xFF60A5FA));
+      expect(theme.chart2, const Color(0xFFFB923C));
+      expect(theme.chart3, const Color(0xFF34D399));
+      expect(theme.chart4, const Color(0xFFC084FC));
+      expect(theme.chart5, const Color(0xFFFB7185));
       expect(theme.radius, const Radius.circular(8));
     });
 
@@ -53,7 +63,7 @@ void main() {
       for (final theme in const [AcmeThemeData.light(), AcmeThemeData.dark()]) {
         final tokens = theme.tokens;
 
-        expect(AcmeTokens.colors, hasLength(14));
+        expect(AcmeTokens.colors, hasLength(19));
         expect(tokens, hasLength(AcmeTokens.colors.length + 1));
         expect(tokens.keys.toSet(), <MixToken<Object?>>{
           ...AcmeTokens.colors,
@@ -2401,8 +2411,13 @@ void main() {
           ),
         );
 
-        expect(palette, hasLength(7));
-        expect(palette.first, theme.data.primary);
+        expect(palette, [
+          theme.data.chart1,
+          theme.data.chart2,
+          theme.data.chart3,
+          theme.data.chart4,
+          theme.data.chart5,
+        ]);
         expect(palette.toSet(), hasLength(palette.length));
         for (final color in palette) {
           expect(
@@ -2418,12 +2433,10 @@ void main() {
       });
     }
 
-    testWidgets('palette follows primary and removes a duplicate', (
-      tester,
-    ) async {
+    testWidgets('palette follows an edited chart token', (tester) async {
       late List<Color> palette;
       final theme = const AcmeThemeData.light().copyWith(
-        primary: const Color(0xFF2563EB),
+        chart1: const Color(0xFF4F46E5),
       );
 
       await tester.pumpWidget(
@@ -2435,9 +2448,8 @@ void main() {
         ),
       );
 
-      expect(palette.first, theme.primary);
-      expect(palette, hasLength(6));
-      expect(palette.toSet(), hasLength(palette.length));
+      expect(palette.first, theme.chart1);
+      expect(palette, hasLength(AcmeTokens.chart.length));
     });
 
     for (final theme in _themes) {

--- a/packages/remix_agent/example/lib/ui/theme/theme_data.dart
+++ b/packages/remix_agent/example/lib/ui/theme/theme_data.dart
@@ -27,6 +27,11 @@ class UiThemeData {
     required this.destructiveForeground,
     required this.border,
     required this.focusRing,
+    required this.chart1,
+    required this.chart2,
+    required this.chart3,
+    required this.chart4,
+    required this.chart5,
     required this.radius,
   });
 
@@ -46,6 +51,11 @@ class UiThemeData {
       destructiveForeground = const Color(0xFFFFFFFF),
       border = const Color(0xFFE5E5E5),
       focusRing = const Color(0xFF737373),
+      chart1 = const Color(0xFF2563EB),
+      chart2 = const Color(0xFFC2410C),
+      chart3 = const Color(0xFF047857),
+      chart4 = const Color(0xFF7E22CE),
+      chart5 = const Color(0xFFBE123C),
       radius = const Radius.circular(8);
 
   /// The neutral dark theme.
@@ -64,6 +74,11 @@ class UiThemeData {
       destructiveForeground = const Color(0xFFFFFFFF),
       border = const Color(0xFF404040),
       focusRing = const Color(0xFFA3A3A3),
+      chart1 = const Color(0xFF60A5FA),
+      chart2 = const Color(0xFFFB923C),
+      chart3 = const Color(0xFF34D399),
+      chart4 = const Color(0xFFC084FC),
+      chart5 = const Color(0xFFFB7185),
       radius = const Radius.circular(8);
 
   /// Value for [UiTokens.background].
@@ -108,6 +123,21 @@ class UiThemeData {
   /// Value for [UiTokens.focusRing].
   final Color focusRing;
 
+  /// Value for [UiTokens.chart1].
+  final Color chart1;
+
+  /// Value for [UiTokens.chart2].
+  final Color chart2;
+
+  /// Value for [UiTokens.chart3].
+  final Color chart3;
+
+  /// Value for [UiTokens.chart4].
+  final Color chart4;
+
+  /// Value for [UiTokens.chart5].
+  final Color chart5;
+
   /// Value for [UiTokens.radius].
   final Radius radius;
 
@@ -131,6 +161,11 @@ class UiThemeData {
         UiTokens.destructiveForeground: destructiveForeground,
         UiTokens.border: border,
         UiTokens.focusRing: focusRing,
+        UiTokens.chart1: chart1,
+        UiTokens.chart2: chart2,
+        UiTokens.chart3: chart3,
+        UiTokens.chart4: chart4,
+        UiTokens.chart5: chart5,
         UiTokens.radius: radius,
       });
 
@@ -150,6 +185,11 @@ class UiThemeData {
     Color? destructiveForeground,
     Color? border,
     Color? focusRing,
+    Color? chart1,
+    Color? chart2,
+    Color? chart3,
+    Color? chart4,
+    Color? chart5,
     Radius? radius,
   }) => UiThemeData(
     background: background ?? this.background,
@@ -166,6 +206,11 @@ class UiThemeData {
     destructiveForeground: destructiveForeground ?? this.destructiveForeground,
     border: border ?? this.border,
     focusRing: focusRing ?? this.focusRing,
+    chart1: chart1 ?? this.chart1,
+    chart2: chart2 ?? this.chart2,
+    chart3: chart3 ?? this.chart3,
+    chart4: chart4 ?? this.chart4,
+    chart5: chart5 ?? this.chart5,
     radius: radius ?? this.radius,
   );
 
@@ -184,6 +229,11 @@ class UiThemeData {
     destructiveForeground,
     border,
     focusRing,
+    chart1,
+    chart2,
+    chart3,
+    chart4,
+    chart5,
     radius,
   ];
 

--- a/packages/remix_agent/example/lib/ui/theme/tokens.dart
+++ b/packages/remix_agent/example/lib/ui/theme/tokens.dart
@@ -70,8 +70,31 @@ abstract final class UiTokens {
   /// follows; nothing else reads this token.
   static const focusRing = ColorToken('ui.color.focus-ring');
 
+  /// First categorical chart series color.
+  ///
+  /// Charts assign [chart1] through [chart5] to series in order; see [chart].
+  /// The shipped themes keep one hue per series in both brightnesses, and
+  /// every value clears 4.5:1 against [background]. That also keeps pie labels,
+  /// which are drawn in [background], readable on their slice.
+  static const chart1 = ColorToken('ui.color.chart-1');
+
+  /// Second categorical chart series color. See [chart1].
+  static const chart2 = ColorToken('ui.color.chart-2');
+
+  /// Third categorical chart series color. See [chart1].
+  static const chart3 = ColorToken('ui.color.chart-3');
+
+  /// Fourth categorical chart series color. See [chart1].
+  static const chart4 = ColorToken('ui.color.chart-4');
+
+  /// Fifth categorical chart series color. See [chart1].
+  static const chart5 = ColorToken('ui.color.chart-5');
+
   /// Corner radius shared by the application's controls.
   static const radius = RadiusToken('ui.radius');
+
+  /// The chart series colors in the order charts assign them.
+  static const chart = <ColorToken>[chart1, chart2, chart3, chart4, chart5];
 
   /// Every color token this layer defines, in declaration order.
   ///
@@ -92,5 +115,10 @@ abstract final class UiTokens {
     destructiveForeground,
     border,
     focusRing,
+    chart1,
+    chart2,
+    chart3,
+    chart4,
+    chart5,
   ];
 }

--- a/packages/remix_cli/CHANGELOG.md
+++ b/packages/remix_cli/CHANGELOG.md
@@ -27,6 +27,8 @@
   glyph aliases.
 - Adds an optional `chart` item backed directly by `mix_chart`. One editable
   recipe generates line, bar, and pie adapters without depending on Fortal.
+  Its palette reads the default theme's `chart1` to `chart5` tokens, which
+  clear 4.5:1 against the page in both shipped themes.
 - Keeps already-installed registry adapters in a focused generation run so a
   new dependency cannot invalidate build_runner's graph and remove them.
 - Every item depends on `theme`. `data_table` also depends on `checkbox`,

--- a/packages/remix_cli/README.md
+++ b/packages/remix_cli/README.md
@@ -25,6 +25,9 @@ update command, registry lockfile, or content-hash protocol.
 The CLI has not been published. The hosted commands below apply after its
 first release. Until then, use the checkout command in this section.
 
+The CLI requires Flutter 3.44 or later (Dart 3.12). With an older SDK, adding
+the dependency fails during version solving.
+
 A project-local development dependency is preferred because the app's lockfile
 pins the CLI version and its bundled templates:
 
@@ -122,6 +125,17 @@ dependencies, formats the authored files, runs generation only for the
 declared `button.g.dart`, and analyzes the installed UI path. It does not create
 or modify `build.yaml`.
 
+The current `mix_generator` writes explicit `this.` qualifiers into generated
+adapters, which `flutter_lints` reports as `unnecessary_this` infos. They do
+not fail the command. To keep `flutter analyze` on the source you own, exclude
+the adapters in `analysis_options.yaml`, matching your `paths.ui`:
+
+```yaml
+analyzer:
+  exclude:
+    - lib/ui/**/*.g.dart
+```
+
 With the default preset and path, the application receives:
 
 ```text
@@ -195,8 +209,9 @@ final chart = SizedBox(
 ```
 
 Charts have no intrinsic height, so give line and bar charts a bounded height
-and pie charts a bounded size. Edit `resolveUiChartPalette` to change the
-shared palette, or pass `palette` or a chart `style` for one instance.
+and pie charts a bounded size. The palette is the theme's `chart1` to
+`chart5` tokens: edit them in `theme/theme_data.dart` to restyle every chart,
+or pass `palette` or a chart `style` for one instance.
 
 `RemixCheckboxGroup`, `RemixRadioGroup`, `RemixTabs`, and
 `RemixAccordionGroup` are behavioral and carry no style, so the registry has

--- a/packages/remix_cli/lib/src/registry/default/templates/chart/chart.dart.tmpl
+++ b/packages/remix_cli/lib/src/registry/default/templates/chart/chart.dart.tmpl
@@ -25,25 +25,13 @@ const _barRadiusToken = ContextToken<BorderRadius>(_resolveBarRadius);
 
 /// Returns the categorical palette shared by this application's charts.
 ///
-/// The first color follows the application's `primary` token. The remaining
-/// colors are local values chosen for separation on the active background.
-/// Edit the two lists below to change every chart, or pass `palette` to one
-/// recipe or generated widget for a local override.
-///
-/// The returned list removes duplicates. A brand whose primary matches one of
-/// the fixed colors therefore keeps a useful palette instead of drawing two
-/// series with the same paint.
-List<Color> resolve{{typePrefix}}ChartPalette(BuildContext context) {
-  final background = {{typePrefix}}Tokens.background.resolve(context);
-  final fixed = background.computeLuminance() < _darkBackgroundLuminance
-      ? _darkCategoricalColors
-      : _lightCategoricalColors;
-
-  return List<Color>.unmodifiable(<Color>{
-    {{typePrefix}}Tokens.primary.resolve(context),
-    ...fixed,
-  });
-}
+/// The colors are the theme's `chart1` through `chart5` tokens in series
+/// order, so editing them in `{{typePrefix}}ThemeData` restyles every chart.
+/// Pass `palette` to one recipe or generated widget for a local override.
+List<Color> resolve{{typePrefix}}ChartPalette(BuildContext context) =>
+    List<Color>.unmodifiable([
+      for (final token in {{typePrefix}}Tokens.chart) token.resolve(context),
+    ]);
 
 /// The application's line and area chart recipe.
 ///
@@ -146,33 +134,6 @@ PieChartStyler {{valuePrefix}}PieChartStyle({
     .tooltip(_chartTooltipStyle())
     .merge(PieChartStyler.create(palette: _paletteProp(palette)))
     .merge(style);
-
-/// Luminance below which the dark categorical palette is used.
-///
-/// This is the WCAG midpoint where white becomes the stronger contrasting
-/// choice than black. It lets a custom dark background select the right list
-/// without adding a brightness field to the existing theme contract.
-const _darkBackgroundLuminance = 0.179;
-
-/// Categorical colors for a light page, excluding the theme's primary color.
-const _lightCategoricalColors = <Color>[
-  Color(0xFF2563EB),
-  Color(0xFFC2410C),
-  Color(0xFF047857),
-  Color(0xFF7E22CE),
-  Color(0xFFBE123C),
-  Color(0xFF0E7490),
-];
-
-/// Categorical colors for a dark page, excluding the theme's primary color.
-const _darkCategoricalColors = <Color>[
-  Color(0xFF60A5FA),
-  Color(0xFFFB923C),
-  Color(0xFF34D399),
-  Color(0xFFC084FC),
-  Color(0xFFFB7185),
-  Color(0xFF22D3EE),
-];
 
 /// Width of a line series.
 const _lineWidth = 2.0;

--- a/packages/remix_cli/lib/src/registry/default/templates/theme/theme_data.dart.tmpl
+++ b/packages/remix_cli/lib/src/registry/default/templates/theme/theme_data.dart.tmpl
@@ -27,6 +27,11 @@ class {{typePrefix}}ThemeData {
     required this.destructiveForeground,
     required this.border,
     required this.focusRing,
+    required this.chart1,
+    required this.chart2,
+    required this.chart3,
+    required this.chart4,
+    required this.chart5,
     required this.radius,
   });
 
@@ -46,6 +51,11 @@ class {{typePrefix}}ThemeData {
       destructiveForeground = const Color(0xFFFFFFFF),
       border = const Color(0xFFE5E5E5),
       focusRing = const Color(0xFF737373),
+      chart1 = const Color(0xFF2563EB),
+      chart2 = const Color(0xFFC2410C),
+      chart3 = const Color(0xFF047857),
+      chart4 = const Color(0xFF7E22CE),
+      chart5 = const Color(0xFFBE123C),
       radius = const Radius.circular(8);
 
   /// The neutral dark theme.
@@ -64,6 +74,11 @@ class {{typePrefix}}ThemeData {
       destructiveForeground = const Color(0xFFFFFFFF),
       border = const Color(0xFF404040),
       focusRing = const Color(0xFFA3A3A3),
+      chart1 = const Color(0xFF60A5FA),
+      chart2 = const Color(0xFFFB923C),
+      chart3 = const Color(0xFF34D399),
+      chart4 = const Color(0xFFC084FC),
+      chart5 = const Color(0xFFFB7185),
       radius = const Radius.circular(8);
 
   /// Value for [{{typePrefix}}Tokens.background].
@@ -108,6 +123,21 @@ class {{typePrefix}}ThemeData {
   /// Value for [{{typePrefix}}Tokens.focusRing].
   final Color focusRing;
 
+  /// Value for [{{typePrefix}}Tokens.chart1].
+  final Color chart1;
+
+  /// Value for [{{typePrefix}}Tokens.chart2].
+  final Color chart2;
+
+  /// Value for [{{typePrefix}}Tokens.chart3].
+  final Color chart3;
+
+  /// Value for [{{typePrefix}}Tokens.chart4].
+  final Color chart4;
+
+  /// Value for [{{typePrefix}}Tokens.chart5].
+  final Color chart5;
+
   /// Value for [{{typePrefix}}Tokens.radius].
   final Radius radius;
 
@@ -131,6 +161,11 @@ class {{typePrefix}}ThemeData {
         {{typePrefix}}Tokens.destructiveForeground: destructiveForeground,
         {{typePrefix}}Tokens.border: border,
         {{typePrefix}}Tokens.focusRing: focusRing,
+        {{typePrefix}}Tokens.chart1: chart1,
+        {{typePrefix}}Tokens.chart2: chart2,
+        {{typePrefix}}Tokens.chart3: chart3,
+        {{typePrefix}}Tokens.chart4: chart4,
+        {{typePrefix}}Tokens.chart5: chart5,
         {{typePrefix}}Tokens.radius: radius,
       });
 
@@ -150,6 +185,11 @@ class {{typePrefix}}ThemeData {
     Color? destructiveForeground,
     Color? border,
     Color? focusRing,
+    Color? chart1,
+    Color? chart2,
+    Color? chart3,
+    Color? chart4,
+    Color? chart5,
     Radius? radius,
   }) => {{typePrefix}}ThemeData(
     background: background ?? this.background,
@@ -166,6 +206,11 @@ class {{typePrefix}}ThemeData {
     destructiveForeground: destructiveForeground ?? this.destructiveForeground,
     border: border ?? this.border,
     focusRing: focusRing ?? this.focusRing,
+    chart1: chart1 ?? this.chart1,
+    chart2: chart2 ?? this.chart2,
+    chart3: chart3 ?? this.chart3,
+    chart4: chart4 ?? this.chart4,
+    chart5: chart5 ?? this.chart5,
     radius: radius ?? this.radius,
   );
 
@@ -184,6 +229,11 @@ class {{typePrefix}}ThemeData {
     destructiveForeground,
     border,
     focusRing,
+    chart1,
+    chart2,
+    chart3,
+    chart4,
+    chart5,
     radius,
   ];
 

--- a/packages/remix_cli/lib/src/registry/default/templates/theme/tokens.dart.tmpl
+++ b/packages/remix_cli/lib/src/registry/default/templates/theme/tokens.dart.tmpl
@@ -70,8 +70,31 @@ abstract final class {{typePrefix}}Tokens {
   /// follows; nothing else reads this token.
   static const focusRing = ColorToken('ui.color.focus-ring');
 
+  /// First categorical chart series color.
+  ///
+  /// Charts assign [chart1] through [chart5] to series in order; see [chart].
+  /// The shipped themes keep one hue per series in both brightnesses, and
+  /// every value clears 4.5:1 against [background]. That also keeps pie labels,
+  /// which are drawn in [background], readable on their slice.
+  static const chart1 = ColorToken('ui.color.chart-1');
+
+  /// Second categorical chart series color. See [chart1].
+  static const chart2 = ColorToken('ui.color.chart-2');
+
+  /// Third categorical chart series color. See [chart1].
+  static const chart3 = ColorToken('ui.color.chart-3');
+
+  /// Fourth categorical chart series color. See [chart1].
+  static const chart4 = ColorToken('ui.color.chart-4');
+
+  /// Fifth categorical chart series color. See [chart1].
+  static const chart5 = ColorToken('ui.color.chart-5');
+
   /// Corner radius shared by the application's controls.
   static const radius = RadiusToken('ui.radius');
+
+  /// The chart series colors in the order charts assign them.
+  static const chart = <ColorToken>[chart1, chart2, chart3, chart4, chart5];
 
   /// Every color token this layer defines, in declaration order.
   ///
@@ -92,5 +115,10 @@ abstract final class {{typePrefix}}Tokens {
     destructiveForeground,
     border,
     focusRing,
+    chart1,
+    chart2,
+    chart3,
+    chart4,
+    chart5,
   ];
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,11 +44,24 @@ melos:
       workspaceChangelog: false
 
     bootstrap:
-      # Mix floors are managed here so the Fortal authoring source is analyzed
-      # against the same runtime as Remix. Unlike `environment` above, this is
-      # safe to manage centrally: melos skips any package that does not already
+      # Every dependency that more than one workspace pubspec declares takes
+      # its constraint from here, so one edit plus `dart run melos bootstrap`
+      # moves it everywhere; that keeps the Fortal authoring source analyzed
+      # against the same Mix as Remix. Unlike `environment` above, this is safe
+      # to manage centrally: melos skips any package that does not already
       # declare the dependency (see `_updateDependencies` in melos), so the
       # apps keep resolving Mix transitively and never gain a direct dependency.
+      # A dependency that only one pubspec declares stays local to it.
+      #
+      # Bootstrap never rewrites the root pubspec, which is not a melos
+      # package. tool/check_dependency_constraints.dart holds the root and
+      # every member to these values, and fails on a shared dependency missing
+      # from this list.
+      #
+      # Workspace packages are listed too. Workspace resolution always uses the
+      # local source, but these hosted constraints keep each manifest
+      # deployable outside the workspace. Release versioning runs with
+      # `--no-dependent-constraints`, so a floor moves only when edited here.
       #
       # Keep these at the versions actually exercised by CI. Declaring an older
       # floor than we test would claim support for a Mix we never build against.
@@ -62,8 +75,18 @@ melos:
         # breaks any consumer that resolves beta.4.
         mix: ^2.2.0-beta.5
         mix_annotations: ^2.2.0-beta.1
+        mix_chart: ^0.0.1-beta.1
+        cupertino_icons: ^1.0.8
+        pub_semver: ^2.2.0
+        yaml: ^3.1.3
+        remix: ^1.0.0-beta.9
+        remix_fortal: ^1.0.0-beta.9
+        remix_ui_icons: ^0.1.0
       dev_dependencies:
+        build_runner: ^2.10.1
         mix_generator: ^2.2.0-beta.3
+        remix_cli: ^0.1.0
+        test: ^1.31.0
 
   scripts:
     # No `release:*` versioning scripts here on purpose. The version workflow
@@ -169,9 +192,14 @@ melos:
         - uv run --frozen --project packages/remix_ui_icons/tool/radix_icons python packages/remix_ui_icons/tool/radix_icons/verify.py
       description: Verify the pinned Radix snapshot, generated icon artifacts, and opt-in index
 
+    constraints:check:
+      run: dart run tool/check_dependency_constraints.dart
+      description: Verify shared dependency constraints match the melos bootstrap config
+
     ci:
       steps:
         - toolchain:check
+        - constraints:check
         - version:align:check
         - mix:consumer:check
         - material:check

--- a/tool/check_dependency_constraints.dart
+++ b/tool/check_dependency_constraints.dart
@@ -1,0 +1,120 @@
+import 'dart:io';
+
+import 'package:yaml/yaml.dart';
+
+/// Verifies every shared dependency constraint comes from the melos config.
+///
+/// `melos bootstrap` rewrites the constraints listed under
+/// `melos.command.bootstrap` into each melos package that already declares
+/// them. Two gaps remain, and this check closes both:
+///
+/// * The workspace root is not a melos package, so bootstrap never rewrites
+///   its own constraints.
+/// * A dependency that several pubspecs declare but the config omits is never
+///   synchronized, so its constraints can drift apart unnoticed.
+///
+/// A dependency declared by a single pubspec stays local to it.
+void main() {
+  final workspaceRoot = Directory.current.absolute;
+  final rootPubspec = File('${workspaceRoot.path}/pubspec.yaml');
+  if (!rootPubspec.existsSync() ||
+      !rootPubspec.readAsStringSync().contains('name: remix_workspace')) {
+    stderr.writeln('Run this checker from the workspace root.');
+    exitCode = 64;
+
+    return;
+  }
+
+  final root = loadYaml(rootPubspec.readAsStringSync()) as YamlMap;
+  final members = (root['workspace'] as YamlList?)?.cast<String>() ?? const [];
+  final bootstrap =
+      ((root['melos'] as YamlMap?)?['command'] as YamlMap?)?['bootstrap']
+          as YamlMap?;
+
+  final failures = <String>[];
+  final managed = <String, String>{};
+  for (final section in const ['dependencies', 'dev_dependencies']) {
+    (bootstrap?[section] as YamlMap?)?.forEach((name, constraint) {
+      final previous = managed[name as String];
+      if (previous != null && previous != '$constraint') {
+        failures.add('melos manages $name as both $previous and $constraint.');
+      }
+      managed[name] = '$constraint';
+    });
+  }
+
+  // Only hosted constraints are compared. SDK, path, and Git dependencies
+  // carry no version to share.
+  final declarations = <String, Map<String, String>>{};
+  // '.' is the workspace root, which is a package in its own right.
+  for (final relativePath in ['.', ...members]) {
+    final pubspec = File(
+      relativePath == '.'
+          ? rootPubspec.path
+          : '${workspaceRoot.path}/$relativePath/pubspec.yaml',
+    );
+    if (!pubspec.existsSync()) {
+      failures.add('$relativePath is missing a pubspec.yaml.');
+      continue;
+    }
+
+    final document = loadYaml(pubspec.readAsStringSync()) as YamlMap;
+    for (final section in const ['dependencies', 'dev_dependencies']) {
+      (document[section] as YamlMap?)?.forEach((name, constraint) {
+        if (constraint == null || constraint is YamlMap) return;
+        declarations.putIfAbsent(name as String, () => {})[relativePath] =
+            '$constraint';
+      });
+    }
+  }
+
+  for (final MapEntry(key: name, value: declared) in declarations.entries) {
+    final expected = managed[name];
+    if (expected == null) {
+      if (declared.length > 1) {
+        failures.add(
+          '$name is declared by ${declared.keys.join(', ')} but is not '
+          'managed by melos.',
+        );
+      }
+      continue;
+    }
+    declared.forEach((relativePath, constraint) {
+      if (constraint != expected) {
+        failures.add(
+          '$relativePath declares $name $constraint, but melos manages '
+          '$expected.',
+        );
+      }
+    });
+  }
+  for (final name in managed.keys) {
+    if (!declarations.containsKey(name)) {
+      failures.add(
+        'melos manages $name, but no workspace pubspec declares it.',
+      );
+    }
+  }
+
+  if (failures.isNotEmpty) {
+    stderr.writeln(
+      'Dependency constraint drift detected (${failures.length}):',
+    );
+    for (final failure in failures) {
+      stderr.writeln('- $failure');
+    }
+    stderr.writeln(
+      'Shared constraints live under melos.command.bootstrap in the root '
+      'pubspec. Change them there, run `dart run melos bootstrap`, and update '
+      "the root pubspec's own entries by hand.",
+    );
+    exitCode = 1;
+
+    return;
+  }
+
+  stdout.writeln(
+    '${managed.length} shared dependency constraints come from melos and '
+    'match in all ${members.length + 1} workspace pubspecs.',
+  );
+}


### PR DESCRIPTION
## Description

- **Chart colors come from the default theme.** The default preset's theme gains `chart1` to `chart5` tokens (the same structure as shadcn/ui's `--chart-1…5`), and the default `chart` recipe's palette reads them in series order. Previously the first series used `primary` and the rest were hard-coded colors picked by background luminance inside `chart.dart`. The shipped values keep the previous accessible hues (blue, orange, green, purple, rose), one hue per series in both brightnesses, each at least 5.17:1 against the page. shadcn's own values drop to 1.72:1 in light mode, so they are not copied.
- **Shared dependency constraints live in melos.** Every dependency declared by more than one workspace pubspec (13, up from 3) is listed under `melos.command.bootstrap`, so one edit plus `dart run melos bootstrap` moves it everywhere. A new `constraints:check` CI step (`tool/check_dependency_constraints.dart`) covers the root pubspec, which bootstrap never rewrites, and fails on a shared dependency the config does not list. SDK/Flutter `environment` stays with `tool/check_toolchain.dart`: melos writes one value into every package, and the published packages keep their Flutter 3.41 floor.
- **Docs.** The CLI README states the Flutter 3.44 / Dart 3.12 requirement. The README and open-code guide explain excluding generated `*.g.dart` adapters from analysis, because `mix_generator` currently emits `this.` qualifiers that `flutter_lints` reports as infos.

The playground and Agent example theme copies are reinstalled from the new templates; the playground keeps its declared indigo customization.

## Validation

- `melos run constraints:check`, `toolchain:check`, `version:align:check` — passed
- `melos run docs:check`, `test:cli`, `generate:check`, `open-code:dogfood:check` — passed
- `melos run open-code:check` (both presets against the checkout, including the fixture suite) — passed
- `dart analyze apps/playground packages/remix_agent/example` — no issues; `flutter test` in the Agent example — 31 passed
- `dart run melos bootstrap` — no pubspec rewrites under the new config
- `tool/check_dependency_constraints.dart` on a copy with three planted drifts — reported all three and exited 1

---

## Checklist

- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors. — The fixture suite asserts the new tokens and palette; the constraint checker runs in CI but has no unit test of its own.
- [x] I have updated or added relevant documentation (doc comments with `///`).
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change. — `remix_cli` is unreleased. A Theme installed by an earlier CLI build lacks `chart1` to `chart5` and needs them added before `add chart`; the open-code guide says so.
