### PR TITLE
chore: require mix_chart beta.3 in catalog consumers

### DIFF
--- a/apps/dashboard/pubspec.yaml
+++ b/apps/dashboard/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   # Workspace resolution uses the local packages during development; these
   # hosted constraints keep the app manifest deployable outside the workspace.
-  mix_chart: ^0.0.1-beta.1
+  mix_chart: ^0.0.1-beta.3
   remix: ^1.0.0-beta.10
   remix_fortal: ^1.0.0-beta.9
 

--- a/apps/playground/pubspec.yaml
+++ b/apps/playground/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   remix_fortal: ^1.0.0-beta.9
   mix_annotations: ^2.2.0-beta.1
   remix_ui_icons: ^0.1.0
-  mix_chart: ^0.0.1-beta.1
+  mix_chart: ^0.0.1-beta.3
 
 dev_dependencies:
   build_runner: ^2.10.1

--- a/docs/fortal.mdx
+++ b/docs/fortal.mdx
@@ -29,7 +29,7 @@ Radix parity surface. Consumer applications do not depend on that package.
 
 ## Installation
 
-The commands below apply after the first CLI release and Remix beta.9.
+The commands below apply after the first CLI release and Remix beta.10.
 For checkout use, follow the [Open Code installation instructions](/open-code#install).
 
 ```bash

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -10,7 +10,7 @@ the [CLI tutorial](/tutorials/settings-screen).
 ## Installation
 
 These docs describe the code in this repository, whose Remix package version
-is `1.0.0-beta.9`. Do not substitute a stable `1.0.0` dependency: the repository
+is `1.0.0-beta.10`. Do not substitute a stable `1.0.0` dependency: the repository
 version is a prerelease, not evidence that a stable release exists.
 
 For this checkout, use Flutter 3.44.0 and its bundled Dart 3.12.0, matching

--- a/packages/remix_cli/CHANGELOG.md
+++ b/packages/remix_cli/CHANGELOG.md
@@ -12,7 +12,8 @@
   application's own `button` and `icon_button` recipes, so adding it installs
   both. It needs the Remix release that ships `RemixToastScope`.
 
-- Require Remix `^1.0.0-beta.9` for the generated Fortal adapters. CI checks
+- Require Remix `^1.0.0-beta.10` for the generated adapters and `mix_chart`
+  `^0.0.1-beta.3` for the optional chart recipe. CI checks
   both presets with checkout Remix. Publication requires the hosted check.
 
 - Adds the `fortal` preset as application-owned source derived from the

--- a/packages/remix_cli/lib/src/registry/default/registry.yaml
+++ b/packages/remix_cli/lib/src/registry/default/registry.yaml
@@ -146,7 +146,7 @@ items:
       - theme
     dependencies:
       mix_annotations: ^2.2.0-beta.1
-      mix_chart: ^0.0.1-beta.1
+      mix_chart: ^0.0.1-beta.3
     devDependencies:
       build_runner: ^2.10.1
       mix_generator: ^2.2.0-beta.3

--- a/packages/remix_cli/lib/src/registry/fortal/registry.yaml
+++ b/packages/remix_cli/lib/src/registry/fortal/registry.yaml
@@ -146,7 +146,7 @@ items:
       - theme
     dependencies:
       mix_annotations: ^2.2.0-beta.1
-      mix_chart: ^0.0.1-beta.1
+      mix_chart: ^0.0.1-beta.3
     devDependencies:
       build_runner: ^2.10.1
       mix_generator: ^2.2.0-beta.3

--- a/packages/remix_cli/test/installer_test.dart
+++ b/packages/remix_cli/test/installer_test.dart
@@ -191,7 +191,7 @@ paths:
       final pubAdd = runner.calls.singleWhere(
         (call) => call.arguments.take(2).join(' ') == 'pub add',
       );
-      expect(pubAdd.arguments, ['pub', 'add', 'mix_chart@^0.0.1-beta.1']);
+      expect(pubAdd.arguments, ['pub', 'add', 'mix_chart@^0.0.1-beta.3']);
       final build = runner.calls.singleWhere(
         (call) => call.arguments.take(3).join(' ') == 'run build_runner build',
       );
@@ -535,7 +535,7 @@ packages:
           ),
         );
         final remixUiIcons = item == 'icons' ? '0.1.0' : null;
-        final mixChart = item == 'chart' ? '0.0.1-beta.1' : null;
+        final mixChart = item == 'chart' ? '0.0.1-beta.3' : null;
         writeRequiredPubspec(
           caseRoot,
           mixChart: mixChart == null ? null : '^$mixChart',
@@ -938,11 +938,11 @@ dependencies:
   remix: $registryRemixConstraint
   mix_annotations: ^2.2.0-beta.1
 dev_dependencies:
-  mix_chart: ^0.0.1-beta.1
+  mix_chart: ^0.0.1-beta.3
   build_runner: ^2.10.1
   mix_generator: ^2.2.0-beta.3
 ''');
-      writeRequiredLock(caseRoot, mixChart: '0.0.1-beta.1');
+      writeRequiredLock(caseRoot, mixChart: '0.0.1-beta.3');
       final before = snapshotFiles(caseRoot);
       final runner = happyRunner(caseRoot);
       final writer = RecordingFileWriter(caseRoot);
@@ -1147,7 +1147,7 @@ RecordingProcessRunner happyRunner(
     if (addMissingDependencies) {
       writeRequiredPubspec(
         root,
-        mixChart: addChartDependency ? '^0.0.1-beta.1' : null,
+        mixChart: addChartDependency ? '^0.0.1-beta.3' : null,
       );
     }
     return successProcessOutput;
@@ -1164,7 +1164,7 @@ RecordingProcessRunner happyRunner(
       writeRequiredLock(
         root,
         remix: lockedRemix,
-        mixChart: addChartDependency ? '0.0.1-beta.1' : null,
+        mixChart: addChartDependency ? '0.0.1-beta.3' : null,
       );
     }
     return successProcessOutput;

--- a/packages/remix_cli/test/registry_test.dart
+++ b/packages/remix_cli/test/registry_test.dart
@@ -124,7 +124,7 @@ items:
         'chart',
       ]);
       expect(chart.dependencies.keys, {'mix_annotations', 'mix_chart'});
-      expect('${chart.dependencies['mix_chart']}', '^0.0.1-beta.1');
+      expect('${chart.dependencies['mix_chart']}', '^0.0.1-beta.3');
       expect(source, contains("import 'package:mix_chart/mix_chart.dart';"));
       expect(source, isNot(contains('remix_fortal')));
       expect(

--- a/packages/remix_fortal/pubspec.yaml
+++ b/packages/remix_fortal/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   remix: ^1.0.0-beta.10
   mix: ^2.2.0-beta.5
   mix_annotations: ^2.2.0-beta.1
-  mix_chart: ^0.0.1-beta.1
+  mix_chart: ^0.0.1-beta.3
   remix_ui_icons: ^0.1.0
 
 dev_dependencies:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -484,10 +484,10 @@ packages:
     dependency: transitive
     description:
       name: mix_chart
-      sha256: fbc284e5626a0021c43f078c55e51570b7dae69d59089302310933d1924bbb91
+      sha256: "2d546782702116f438445ea20090f3bb20a343805536ec183c202b5c9b87ab6a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.1-beta.1"
+    version: "0.0.1-beta.3"
   mix_generator:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,7 +75,7 @@ melos:
         # breaks any consumer that resolves beta.4.
         mix: ^2.2.0-beta.5
         mix_annotations: ^2.2.0-beta.1
-        mix_chart: ^0.0.1-beta.1
+        mix_chart: ^0.0.1-beta.3
         cupertino_icons: ^1.0.8
         pub_semver: ^2.2.0
         yaml: ^3.1.3


### PR DESCRIPTION
## Description

Raise the optional chart dependency floor from `^0.0.1-beta.1` to the published `^0.0.1-beta.3` in workspace consumers and both CLI presets. Update installer fixtures and correct current installation docs to Remix beta.10.

Core Remix gains no chart dependency. Flutter/Dart minimums are unchanged.

## Related Issues

No linked issue.

## Validation

- Full `dart run melos run ci --no-select` passed, including fresh default and Fortal consumer installs with hosted chart beta.3.
- `flutter analyze` and `git diff --check` passed.
- Remix publish dry-run passed with zero warnings.
- CLI publish dry-run passed on the committed head with zero warnings.

The consumer tests use checkout Remix. Publish Remix beta.10 before running the hosted CLI release gate; this PR does not publish either package.

## Checklist

- [x] My PR includes unit or integration tests for all changed/updated/fixed behaviors.
- [x] I have updated or added relevant documentation.
- [x] I am prepared to follow up on review comments in a timely manner.

## Breaking Change

Does this PR require users of the package to manually update their code?

- [ ] Yes, this is a breaking change.
- [x] No, this is not a breaking change.